### PR TITLE
fix(via-router): decrease the branch capacity to 32 

### DIFF
--- a/via-router/src/router.rs
+++ b/via-router/src/router.rs
@@ -7,7 +7,7 @@ use crate::path::{self, Param, Pattern, Split};
 /// The capacity of the vec used to store indices (usize) to the children of
 /// the nodes that matched the last path segment.
 ///
-const VISIT_BRANCH_CAPACITY: usize = 128;
+const VISIT_BRANCH_CAPACITY: usize = 32;
 
 #[derive(Debug)]
 pub struct Node<T> {


### PR DESCRIPTION
Increases the preallocated size of the branch vector to roughly `1kb`. This should result in a single allocation for the branch vec for the vast majority of applications. Even those with many routes in an unbalanced tree.