### PR TITLE
style(via-router): prefer ? instead of double match

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-via-router = { path = "./via-router" }
+via-router = { version = "3.0.0-beta.24" }
 
 [dependencies.cookie]
 version = "0.18"


### PR DESCRIPTION
Prefers using `?` to terminate the iterator. It leaves the iterator in the exact state that it was in the final time that it was called. This is great for correctness and important if we ever want to introduce a concurrent version of the router that searches branches across multiple CPU cores for resolving deeply nested graphql query fields. There is no risk in leaving the iterator in the state that it was in the last time that it was called as it's destructor runs predictably. Also, the iterator is consumed synchronously so we know it'll be dropped before any code in user land is called.