### PR TITLE
fix(via): path param parse double boxes error

### DIFF
--- a/src/request/param/path_param.rs
+++ b/src/request/param/path_param.rs
@@ -45,13 +45,7 @@ impl<'a, 'b, T: DecodeParam> PathParam<'a, 'b, T> {
         U: FromStr,
         U::Err: std::error::Error + Send + Sync + 'static,
     {
-        match self.into_result()?.parse() {
-            Ok(value) => Ok(value),
-            Err(error) => {
-                let source = Box::new(error);
-                Err(Error::bad_request(source))
-            }
-        }
+        self.into_result()?.parse().map_err(Error::bad_request)
     }
 
     /// Returns a result with the parameter value if it exists. If the param is


### PR DESCRIPTION
If a path param cannot be parsed for whatever reason the error ends up getting boxed twice due to recent API changes. This PR prevents that from happening.