### PR TITLE
fix(via): accidental rename of via::Route

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::router::{Router, Scope};
+use super::router::{Route, Router};
 use crate::middleware::Middleware;
 
 pub struct App<T> {
@@ -18,8 +18,8 @@ pub fn app<T>(state: T) -> App<T> {
 }
 
 impl<T> App<T> {
-    pub fn at(&mut self, path: &'static str) -> Scope<'_, T> {
-        Scope {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
+        Route {
             inner: self.router.at(path),
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,5 +3,5 @@ mod router;
 mod service;
 
 pub use app::{App, app};
-pub use router::Scope;
+pub use router::Route;
 pub(crate) use service::AppService;

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -4,13 +4,13 @@ use crate::middleware::Middleware;
 
 pub type Router<T> = via_router::Router<Arc<dyn Middleware<T>>>;
 
-pub struct Scope<'a, T> {
+pub struct Route<'a, T> {
     pub(super) inner: via_router::RouteMut<'a, Arc<dyn Middleware<T>>>,
 }
 
-impl<T> Scope<'_, T> {
-    pub fn at(&mut self, path: &'static str) -> Scope<'_, T> {
-        Scope {
+impl<T> Route<'_, T> {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
+        Route {
             inner: self.inner.at(path),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ mod middleware;
 mod next;
 mod server;
 
-pub use app::{App, Scope, app};
+pub use app::{App, Route, app};
 pub use builtin::resource::{connect, delete, get, head, options, patch, post, put, trace};
 pub use error::{BoxError, Error};
 pub use middleware::{BoxFuture, Middleware, Result};


### PR DESCRIPTION
Looks like an experimental rename made it's way in to main. This PR renames `Scope` back to `Route` before releasing the next version. 