### PR TITLE
docs(via): explain why we want Cell<bool> in accept

### DIFF
--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -57,6 +57,9 @@ where
 
     // A flag that tracks whether or not there are inflight connections that
     // can be joined.
+    //
+    // Using Cell<bool> makes reads and writes explicit and accidental movement
+    // a compiler error. These are all things we want in such a hot path.
     let try_join = Cell::new(false);
 
     // Wrap app in an arc so it can be cloned into the connection task.


### PR DESCRIPTION
Provides context around why we prefer `Cell<bool>` in the accept loop. Based on https://github.com/zacharygolba/via/pull/214#discussion_r2331424728.