### PR TITLE
fix(via): prefer batching joins in accept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,17 @@ ring = ["dep:ring", "tokio-rustls/ring", "tokio-websockets/ring"]
 
 rustls = ["dep:tokio-rustls"]
 
-ws = ["dep:base64", "dep:bytestring", "dep:tokio-websockets"]
+ws = [
+    "dep:base64",
+    "dep:bytestring",
+    "dep:futures-sink",
+    "dep:futures-util",
+    "dep:tokio-websockets",
+]
 
 [dependencies]
 bytes = "1"
-futures = { version = "0.3", default-features = false }
+futures-core = "0.3"
 http = "1"
 http-body = "1"
 http-body-util = "0.1"
@@ -55,6 +61,15 @@ optional = true
 [dependencies.cookie]
 version = "0.18"
 features = ["percent-encode"]
+
+[dependencies.futures-sink]
+version = "0.3"
+optional = true
+
+[dependencies.futures-util]
+version = "0.3"
+features = ["sink"]
+optional = true
 
 [dependencies.ring]
 version = "0.17"

--- a/src/builtin/ws.rs
+++ b/src/builtin/ws.rs
@@ -2,7 +2,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as base64_engine;
 use bytes::{Buf, Bytes};
 use bytestring::ByteString;
-use futures::{SinkExt, StreamExt};
+use futures_util::{SinkExt, StreamExt};
 use http::{StatusCode, Uri, header};
 use hyper_util::rt::TokioIo;
 use std::sync::Arc;

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use cookie::CookieJar;
-use futures::Stream;
+use futures_core::Stream;
 use http::header::{CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING};
 use http::{HeaderName, HeaderValue, StatusCode, Version};
 use http_body::Frame;

--- a/src/response/file.rs
+++ b/src/response/file.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use futures::Stream;
+use futures_core::Stream;
 use http::header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, LAST_MODIFIED};
 use http_body::Frame;
 use httpdate::HttpDate;


### PR DESCRIPTION
Adds an unconditional GC sweep to accept to balance latency with throughput. We still try to join a connection opportunistically while there are connections in the join set. The result should be more stability and slightly higher latency under load.