### PR TITLE
fix(via): avoid extra bounds check in BufferBody

### DIFF
--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -42,11 +42,7 @@ impl Body for BufferBody {
             Poll::Ready(None)
         } else {
             let len = adapt_frame_size(remaining);
-            let data = buf.slice(..len);
-
-            buf.advance(len);
-
-            Poll::Ready(Some(Ok(Frame::data(data))))
+            Poll::Ready(Some(Ok(Frame::data(buf.split_to(len)))))
         }
     }
 


### PR DESCRIPTION
Switches back to `split_to` but keeps the relative adaptive frame length in `BufferBody`. This change avoids an extra bounds check. 