### PR TITLE
fix(via): ws::Message is non_exhaustive

### DIFF
--- a/src/builtin/ws.rs
+++ b/src/builtin/ws.rs
@@ -31,6 +31,7 @@ type OnUpgrade<T> =
     dyn Fn(WebSocket, RequestContext<T>) -> BoxFuture<Result<(), Error>> + Send + Sync;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Message {
     Binary(Bytes),
     Close(Option<(CloseCode, Option<ByteString>)>),

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -8,7 +8,7 @@ use crate::response::Response;
 
 /// The output of the `Future` returned from middleware.
 ///
-pub type Result = std::result::Result<Response, Error>;
+pub type Result<T = Response> = std::result::Result<T, Error>;
 pub type BoxFuture<T = Result> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 
 pub trait Middleware<T>: Send + Sync {


### PR DESCRIPTION
Makes `ws::Message` `non_exhaustive` and updates the chat example to reflect that.

If new message types get added to the spec, we won't have to release a major version in order to support the new message type.