### PR TITLE
refactor(via): prefer App::new and via::serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below is a basic example to demonstrate how to use Via to create a simple web se
 ```rust
 use std::process::ExitCode;
 use via::builtin::rescue;
-use via::{BoxError, Next, Request, Response};
+use via::{App, BoxError, Next, Request, Response};
 
 async fn hello(request: Request, _: Next) -> via::Result {
     // Get a reference to the path parameter `name` from the request uri.
@@ -38,8 +38,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, BoxError> {
-    // Create a new application.
-    let mut app = via::app(());
+    let mut app = App::new(());
 
     // Capture errors from downstream, log them, and map them into responses.
     // Upstream middleware remains unaffected and continues execution.
@@ -48,7 +47,7 @@ async fn main() -> Result<ExitCode, BoxError> {
     // Define a route that listens on /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));
 
-    via::start(app).listen(("127.0.0.1", 8080)).await
+    via::serve(app).listen(("127.0.0.1", 8080)).await
 }
 ```
 

--- a/examples/blog-api/src/api/posts.rs
+++ b/examples/blog-api/src/api/posts.rs
@@ -1,21 +1,21 @@
 use via::{Next, Request, Response};
 
 use crate::database::models::post::*;
-use crate::State;
+use crate::BlogApi;
 
-pub async fn auth(request: Request<State>, next: Next<State>) -> via::Result {
+pub async fn auth(request: Request<BlogApi>, next: Next<BlogApi>) -> via::Result {
     println!("authenticate");
     next.call(request).await
 }
 
-pub async fn index(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn index(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let state = request.state();
     let posts = Post::public(&state.pool).await?;
 
     Response::build().json(&posts)
 }
 
-pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn create(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let (head, body) = request.into_parts();
     let state = head.state();
 
@@ -25,7 +25,7 @@ pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
     Response::build().status(201).json(&post)
 }
 
-pub async fn show(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn show(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let state = request.state();
     let id = request.param("id").parse()?;
 
@@ -34,7 +34,7 @@ pub async fn show(request: Request<State>, _: Next<State>) -> via::Result {
     Response::build().json(&post)
 }
 
-pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn update(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let (head, body) = request.into_parts();
     let state = head.state();
     let id = head.param("id").parse()?;
@@ -45,7 +45,7 @@ pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
     Response::build().json(&post)
 }
 
-pub async fn destroy(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn destroy(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let state = request.state();
     let id = request.param("id").parse()?;
 

--- a/examples/blog-api/src/api/users.rs
+++ b/examples/blog-api/src/api/users.rs
@@ -1,16 +1,16 @@
 use via::{Next, Request, Response};
 
 use crate::database::models::user::*;
-use crate::State;
+use crate::BlogApi;
 
-pub async fn index(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn index(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let state = request.state();
     let users = User::all(&state.pool).await?;
 
     Response::build().json(&users)
 }
 
-pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn create(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let (head, body) = request.into_parts();
     let state = head.state();
 
@@ -20,7 +20,7 @@ pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
     Response::build().status(201).json(&user)
 }
 
-pub async fn show(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn show(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let state = request.state();
     let id = request.param("id").parse()?;
 
@@ -29,7 +29,7 @@ pub async fn show(request: Request<State>, _: Next<State>) -> via::Result {
     Response::build().json(&user)
 }
 
-pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn update(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let (head, body) = request.into_parts();
     let state = head.state();
     let id = head.param("id").parse()?;
@@ -40,7 +40,7 @@ pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
     Response::build().json(&user)
 }
 
-pub async fn destroy(request: Request<State>, _: Next<State>) -> via::Result {
+pub async fn destroy(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let state = request.state();
     let id = request.param("id").parse()?;
 

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -4,7 +4,7 @@ mod room;
 use http::header;
 use std::process::ExitCode;
 use via::builtin::rescue;
-use via::{BoxError, Response};
+use via::{App, BoxError, Response};
 
 use crate::chat::Chat;
 
@@ -12,8 +12,7 @@ const CSP: &str = "default-src 'self'; connect-src 'self'";
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, BoxError> {
-    // Create a new application.
-    let mut app = via::app(Chat::new());
+    let mut app = App::new(Chat::new());
 
     // Capture errors from downstream, log them, and map them into responses.
     // Upstream middleware remains unaffected and continues execution.
@@ -40,5 +39,5 @@ async fn main() -> Result<ExitCode, BoxError> {
         route.at("/:index").respond(via::get(room::show));
     });
 
-    via::start(app).listen(("127.0.0.1", 8080)).await
+    via::serve(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,11 +1,11 @@
 use cookie::{Cookie, Key};
 use std::process::ExitCode;
 use via::builtin::{cookies, rescue};
-use via::{BoxError, Next, Request, Response};
+use via::{App, BoxError, Next, Request, Response};
 
 /// A struct used to store application state.
 ///
-struct State {
+struct Cookies {
     /// The secret key used to sign, verify, and optionally encrypt cookies. The
     /// value of this key should be kept secret and changed periodically.
     ///
@@ -15,7 +15,7 @@ struct State {
 /// Responds with a greeting message with the name provided in the request uri
 /// path.
 ///
-async fn hello(request: Request<State>, _: Next<State>) -> via::Result {
+async fn hello(request: Request<Cookies>, _: Next<Cookies>) -> via::Result {
     // Get a reference to the path parameter `name` from the request uri.
     let name = request.param("name").percent_decode().into_result()?;
 
@@ -26,7 +26,7 @@ async fn hello(request: Request<State>, _: Next<State>) -> via::Result {
 /// Increments the value of the "n_visits" counter to the console. Returns a
 /// response with a message confirming the operation was successful.
 ///
-async fn count_visits(request: Request<State>, next: Next<State>) -> via::Result {
+async fn count_visits(request: Request<Cookies>, next: Next<Cookies>) -> via::Result {
     // Clone the state from the request so we can access the secret key after
     // passing ownership of the request to the next middleware.
     //
@@ -94,8 +94,8 @@ async fn main() -> Result<ExitCode, BoxError> {
     //
     dotenvy::dotenv().ok();
 
-    // Create a new app by calling the `via::app` function.
-    let mut app = via::app(State {
+    // Create a new application.
+    let mut app = App::new(Cookies {
         secret: get_secret_from_env(),
     });
 
@@ -114,5 +114,5 @@ async fn main() -> Result<ExitCode, BoxError> {
     // Add a route that responds with a greeting message.
     app.at("/hello/:name").respond(via::get(hello));
 
-    via::start(app).listen(("127.0.0.1", 8080)).await
+    via::serve(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 use via::builtin::rescue;
-use via::{BoxError, Next, Pipe, Request, Response};
+use via::{App, BoxError, Next, Pipe, Request, Response};
 
 async fn echo(request: Request, _: Next) -> via::Result {
     request.pipe(Response::build())
@@ -8,7 +8,7 @@ async fn echo(request: Request, _: Next) -> via::Result {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, BoxError> {
-    let mut app = via::app(());
+    let mut app = App::new(());
 
     // Capture errors from downstream, log them, and map them into responses.
     // Upstream middleware remains unaffected and continues execution.
@@ -22,5 +22,5 @@ async fn main() -> Result<ExitCode, BoxError> {
     // `via::post` function is used to specify that the `echo` middleware should
     // only accept POST requests.
 
-    via::start(app).listen(("127.0.0.1", 8080)).await
+    via::serve(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/file-server/src/main.rs
+++ b/examples/file-server/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use via::builtin::rescue;
 use via::response::File;
-use via::{BoxError, Next, Request};
+use via::{App, BoxError, Next, Request};
 
 /// The maximum amount of memory that will be allocated to serve a single file.
 ///
@@ -56,8 +56,7 @@ fn resolve_path(path_param: &str) -> PathBuf {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, BoxError> {
-    // Create a new application.
-    let mut app = via::app(());
+    let mut app = App::new(());
 
     // Capture errors from downstream, log them, and map them into responses.
     // Upstream middleware remains unaffected and continues execution.
@@ -66,5 +65,5 @@ async fn main() -> Result<ExitCode, BoxError> {
     // Serve any file located in the public dir.
     app.at("/*path").respond(via::get(file_server).or_next());
 
-    via::start(app).listen(("127.0.0.1", 8080)).await
+    via::serve(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 use via::builtin::rescue;
-use via::{BoxError, Next, Request, Response};
+use via::{App, BoxError, Next, Request, Response};
 
 async fn hello(request: Request, _: Next) -> via::Result {
     // Get a reference to the path parameter `name` from the request uri.
@@ -12,8 +12,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, BoxError> {
-    // Create a new application.
-    let mut app = via::app(());
+    let mut app = App::new(());
 
     // Capture errors from downstream, log them, and map them into responses.
     // Upstream middleware remains unaffected and continues execution.
@@ -22,5 +21,5 @@ async fn main() -> Result<ExitCode, BoxError> {
     // Define a route that listens on /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));
 
-    via::start(app).listen(("127.0.0.1", 8080)).await
+    via::serve(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -2,7 +2,7 @@ mod tls;
 
 use std::process::ExitCode;
 use via::builtin::rescue;
-use via::{BoxError, Next, Request, Response};
+use via::{App, BoxError, Next, Request, Response};
 
 async fn hello(request: Request, _: Next) -> via::Result {
     // Get a reference to the path parameter `name` from the request uri.
@@ -18,8 +18,7 @@ async fn main() -> Result<ExitCode, BoxError> {
     // doing anything else.
     let tls_config = tls::server_config().expect("tls config is invalid or missing");
 
-    // Create a new app by calling the `via::app` function.
-    let mut app = via::app(());
+    let mut app = App::new(());
 
     // Capture errors from downstream, log them, and map them into responses.
     // Upstream middleware remains unaffected and continues execution.
@@ -28,7 +27,7 @@ async fn main() -> Result<ExitCode, BoxError> {
     // Add our hello responder to the endpoint /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));
 
-    via::start(app)
+    via::serve(app)
         .rustls_config(tls_config)
         .listen(("127.0.0.1", 8080))
         .await

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -8,16 +8,16 @@ pub struct App<State> {
     pub(super) router: Router<State>,
 }
 
-/// Constructs a new [`App`] with the provided `state` argument.
-///
-pub fn app<State>(state: State) -> App<State> {
-    App {
-        state: Arc::new(state),
-        router: Router::new(),
-    }
-}
-
 impl<State> App<State> {
+    /// Constructs a new [`App`] with the provided `state` argument.
+    ///
+    pub fn new(state: State) -> Self {
+        App {
+            state: Arc::new(state),
+            router: Router::new(),
+        }
+    }
+
     pub fn at(&mut self, path: &'static str) -> Route<'_, State> {
         Route {
             inner: self.router.at(path),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,6 @@ mod app;
 mod router;
 mod service;
 
-pub use app::{App, app};
+pub use app::App;
 pub use router::Route;
 pub(crate) use service::AppService;

--- a/src/error.rs
+++ b/src/error.rs
@@ -325,11 +325,11 @@ impl Error {
     ///
     /// ```
     /// use via::builtin::rescue;
-    /// use via::{BoxError, Next, Request};
+    /// use via::{App, BoxError, Next, Request};
     ///
     /// #[tokio::main(flavor = "current_thread")]
     /// async fn main() -> Result<(), BoxError> {
-    ///     let mut app = via::app(());
+    ///     let mut app = App::new(());
     ///
     ///     // Add a rescue middleware to the route tree that maps errors that
     ///     // occur in subsequent middleware by calling the `redact` function.
@@ -394,11 +394,11 @@ impl Error {
     ///
     /// ```
     /// use via::builtin::rescue;
-    /// use via::{BoxError, Next, Request};
+    /// use via::{App, BoxError, Next, Request};
     ///
     /// #[tokio::main(flavor = "current_thread")]
     /// async fn main() -> Result<(), BoxError> {
-    ///     let mut app = via::app(());
+    ///     let mut app = App::new(());
     ///
     ///     // Add a rescue middleware to the route tree that maps errors that
     ///     // occur in subsequent middleware by calling the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! ```no_run
 //! use std::process::ExitCode;
 //! use via::builtin::rescue;
-//! use via::{BoxError, Next, Request, Response, Server};
+//! use via::{App, BoxError, Next, Request, Response};
 //!
 //! async fn hello(request: Request, _: Next) -> via::Result {
 //!     // Get a reference to the path parameter `name` from the request uri.
@@ -29,8 +29,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<ExitCode, BoxError> {
-//!     // Create a new application.
-//!     let mut app = via::app(());
+//!     let mut app = App::new(());
 //!
 //!     // Capture errors from downstream, log them, and map them into responses.
 //!     // Upstream middleware remains unaffected and continues execution.
@@ -39,7 +38,7 @@
 //!     // Define a route that listens on /hello/:name.
 //!     app.at("/hello/:name").respond(via::get(hello));
 //!
-//!     via::start(app).listen(("127.0.0.1", 8080)).await
+//!     via::serve(app).listen(("127.0.0.1", 8080)).await
 //! }
 //! ```
 //!
@@ -56,14 +55,15 @@ mod middleware;
 mod next;
 mod server;
 
-pub use app::{App, Route, app};
+pub use app::{App, Route};
 pub use builtin::allow::{delete, get, head, options, patch, post, put, trace};
 pub use error::{BoxError, Error, ErrorMessage};
 pub use middleware::{BoxFuture, Middleware, Result};
 pub use next::Next;
 pub use request::Request;
 pub use response::{Pipe, Response};
-pub use server::{Server, start};
+pub use server::{Server, serve};
 
 #[cfg(feature = "ws")]
+#[doc(inline)]
 pub use builtin::ws::ws;

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -29,8 +29,8 @@ pub struct RequestHead<T> {
     pub(crate) cookies: CookieJar,
 
     /// The shared application state passed to the
-    /// [`via::app`](crate::app::app)
-    /// function.
+    /// [`App`](crate::App)
+    /// constructor.
     ///
     pub(crate) state: Arc<T>,
 }
@@ -208,8 +208,8 @@ impl<T> Request<T> {
 
     /// Returns a thread-safe reference-counting pointer to the application
     /// state that was passed as an argument to the
-    /// [`via::app`](crate::app::app)
-    /// function.
+    /// [`App`](crate::App)
+    /// constructor.
     ///
     #[inline]
     pub fn state(&self) -> &Arc<T> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,4 +6,4 @@ mod acceptor;
 mod io;
 mod server;
 
-pub use server::{Server, start};
+pub use server::{Server, serve};


### PR DESCRIPTION
Removes `via::app` in favor of an app constructor and renames `via::start` to `via::serve`.

This change makes `via::serve` the only top-level function that is not a builtin middleware. Every other function is either a variation of `Allow` that corresponds to an HTTP method or `via::ws` if the `ws` flag is enabled.