### PR TITLE
fix(via): accept takes Arc<A> where A: Acceptor

### DIFF
--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -30,7 +30,7 @@ macro_rules! log {
 #[inline(never)]
 pub async fn accept<A, T>(
     listener: TcpListener,
-    acceptor: A,
+    acceptor: Arc<A>,
     service: AppService<T>,
     config: ServerConfig,
 ) -> ExitCode
@@ -98,7 +98,7 @@ where
             },
         };
 
-        let mut acceptor = acceptor.clone();
+        let acceptor = acceptor.clone();
         let service = service.clone();
         let mut shutdown_rx = shutdown_rx.clone();
 

--- a/src/server/acceptor/acceptor.rs
+++ b/src/server/acceptor/acceptor.rs
@@ -5,12 +5,12 @@ use tokio::net::TcpStream;
 
 /// A trait for types that can accept a TcpStream.
 ///
-pub trait Acceptor: Clone + Send + Sync {
-    type Future: Future<Output = Result<Self::Stream, io::Error>> + Send + Sync;
+pub trait Acceptor: Send + Sync {
+    type Future: Future<Output = io::Result<Self::Stream>> + Send + Sync;
     type Stream: AsyncRead + AsyncWrite + Send + Sync + Unpin;
 
     /// Defines how to accept a TcpStream. If the connection is served over TLS,
     /// this is where the TLS handshake would be performed.
     ///
-    fn accept(&mut self, stream: TcpStream) -> Self::Future;
+    fn accept(&self, stream: TcpStream) -> Self::Future;
 }

--- a/src/server/acceptor/http.rs
+++ b/src/server/acceptor/http.rs
@@ -6,15 +6,11 @@ use super::Acceptor;
 
 /// Accepts a TCP stream and returns it as-is.
 ///
-#[derive(Clone)]
-pub struct HttpAcceptor(
-    // Pad HttpAcceptor with usize to avoid passing a ZST to accept.
-    #[allow(dead_code)] usize,
-);
+pub struct HttpAcceptor;
 
 impl HttpAcceptor {
     pub fn new() -> Self {
-        Self(0)
+        Self
     }
 }
 
@@ -22,7 +18,8 @@ impl Acceptor for HttpAcceptor {
     type Future = Ready<Result<Self::Stream, io::Error>>;
     type Stream = TcpStream;
 
-    fn accept(&mut self, stream: TcpStream) -> Self::Future {
+    #[inline]
+    fn accept(&self, stream: TcpStream) -> Self::Future {
         future::ready(Ok(stream))
     }
 }

--- a/src/server/acceptor/rustls.rs
+++ b/src/server/acceptor/rustls.rs
@@ -8,7 +8,6 @@ pub use rustls::ServerConfig as RustlsConfig;
 
 use super::Acceptor;
 
-#[derive(Clone)]
 pub struct RustlsAcceptor {
     acceptor: TlsAcceptor,
 }
@@ -25,7 +24,8 @@ impl Acceptor for RustlsAcceptor {
     type Future = Accept<TcpStream>;
     type Stream = TlsStream<TcpStream>;
 
-    fn accept(&mut self, stream: TcpStream) -> Self::Future {
+    #[inline]
+    fn accept(&self, stream: TcpStream) -> Self::Future {
         self.acceptor.accept(stream)
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -158,7 +158,7 @@ where
 
         let exit = accept(
             TcpListener::bind(address).await?,
-            RustlsAcceptor::new(rustls_config),
+            Arc::new(RustlsAcceptor::new(rustls_config)),
             AppService::new(Arc::new(self.app), self.config.max_request_size),
             self.config,
         );
@@ -173,7 +173,7 @@ where
     {
         let exit = accept(
             TcpListener::bind(address).await?,
-            HttpAcceptor::new(),
+            Arc::new(HttpAcceptor::new()),
             AppService::new(Arc::new(self.app), self.config.max_request_size),
             self.config,
         );


### PR DESCRIPTION
Requires that the `Acceptor` that is passed to accept is wrapped in an Arc rather than requiring that `Acceptor: Clone`. This makes it explicit that each time acceptor is cloned we are doing an atomic increment to the acceptor's ref count.