### PR TITLE
chore(via): bump version to 2.0.0-rc.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.47"
+version = "2.0.0-rc.48"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.47"
+via = "2.0.0-rc.48"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
Bumps via to `v2.0.0-rc.48`

---

### Changelog

- #267
- #266
- #265
- #264
- #263
- #262