### PR TITLE
refactor(via): clean up tls adaptors

### DIFF
--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -1,57 +1,54 @@
-use hyper::rt::{Read, Write};
-use hyper_util::rt::TokioIo;
+use hyper::rt::{Read, ReadBufCursor, Write};
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::OwnedSemaphorePermit;
 
 pub(crate) struct IoWithPermit<T> {
+    io: T,
     _permit: OwnedSemaphorePermit,
-    io: TokioIo<T>,
 }
 
 impl<T> IoWithPermit<T> {
     #[inline]
-    pub fn new(permit: OwnedSemaphorePermit, io: T) -> Self {
-        Self {
-            _permit: permit,
-            io: TokioIo::new(io),
-        }
+    pub fn new(io: T, _permit: OwnedSemaphorePermit) -> Self {
+        Self { io, _permit }
     }
 }
 
-impl<T> Read for IoWithPermit<T>
-where
-    T: AsyncRead + Unpin,
-{
+impl<T: Unpin> IoWithPermit<T> {
+    #[inline(always)]
+    fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
+        let this = self.get_mut();
+        Pin::new(&mut this.io)
+    }
+}
+
+impl<T: Read + Unpin> Read for IoWithPermit<T> {
     fn poll_read(
-        mut self: Pin<&mut Self>,
-        context: &mut Context<'_>,
-        buf: hyper::rt::ReadBufCursor<'_>,
+        self: Pin<&mut Self>,
+        context: &mut Context,
+        buf: ReadBufCursor,
     ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.io).poll_read(context, buf)
+        self.project().poll_read(context, buf)
     }
 }
 
-impl<T> Write for IoWithPermit<T>
-where
-    T: AsyncWrite + Unpin,
-{
+impl<T: Write + Unpin> Write for IoWithPermit<T> {
     fn poll_write(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         context: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.io).poll_write(context, buf)
+        self.project().poll_write(context, buf)
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.io).poll_flush(context)
+    fn poll_flush(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().poll_flush(context)
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.io).poll_shutdown(context)
+    fn poll_shutdown(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().poll_shutdown(context)
     }
 
     fn is_write_vectored(&self) -> bool {
@@ -59,10 +56,10 @@ where
     }
 
     fn poll_write_vectored(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         context: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.io).poll_write_vectored(context, bufs)
+        self.project().poll_write_vectored(context, bufs)
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,6 +4,8 @@
 mod accept;
 mod io;
 mod server;
+
+#[cfg(any(feature = "native-tls", feature = "rustls"))]
 mod tls;
 
 use accept::accept;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -152,7 +152,7 @@ where
             let exit = super::accept(
                 config,
                 TcpListener::bind(address).await?,
-                Arc::new(async |stream| Ok(stream)),
+                Box::new(|stream| async { Ok(stream) }),
                 service,
             );
 

--- a/src/server/tls/native.rs
+++ b/src/server/tls/native.rs
@@ -1,7 +1,6 @@
 use native_tls::{Identity, Protocol};
 use std::future::Future;
 use std::process::ExitCode;
-use std::sync::Arc;
 use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio_native_tls::TlsAcceptor;
 
@@ -34,7 +33,7 @@ where
                 .expect("failed to build native_tls::TlsAcceptor"),
         );
 
-        Arc::new(move |stream| {
+        Box::new(move |stream| {
             let acceptor = acceptor.clone();
             async move { Ok(acceptor.accept(stream).await?) }
         })

--- a/src/server/tls/rustls.rs
+++ b/src/server/tls/rustls.rs
@@ -1,13 +1,22 @@
 use std::future::Future;
+use std::io;
+use std::pin::Pin;
 use std::process::ExitCode;
 use std::sync::Arc;
-use tokio::net::{TcpListener, ToSocketAddrs};
-use tokio_rustls::server::TlsAcceptor;
+use std::task::{Context, Poll, ready};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio_rustls::server::{Accept, TlsAcceptor, TlsStream};
 
 use super::super::accept;
 use super::super::server::ServerConfig;
 use crate::app::AppService;
 use crate::error::BoxError;
+
+enum Negotiate {
+    Ready(TlsStream<TcpStream>),
+    Pending(Accept<TcpStream>),
+}
 
 pub fn listen_rustls<State, A>(
     config: ServerConfig,
@@ -21,9 +30,13 @@ where
 {
     let handshake = {
         let acceptor = TlsAcceptor::from(Arc::new(tls_config));
-        Arc::new(move |stream| {
+        Box::new(move |stream| {
             let acceptor = acceptor.clone();
-            async move { Ok(acceptor.accept(stream).await?) }
+            async move {
+                let mut stream = Box::pin(Negotiate::Pending(acceptor.accept(stream)));
+                stream.as_mut().await?;
+                Ok(stream)
+            }
         })
     };
 
@@ -36,5 +49,80 @@ where
         );
 
         Ok(exit.await)
+    }
+}
+
+impl AsyncRead for Negotiate {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        context: &mut Context,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if let Self::Ready(stream) = self.get_mut() {
+            Pin::new(stream).poll_read(context, buf)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl AsyncWrite for Negotiate {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        context: &mut Context,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if let Self::Ready(stream) = self.get_mut() {
+            Pin::new(stream).poll_write(context, buf)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, context: &mut Context) -> Poll<io::Result<()>> {
+        if let Self::Ready(stream) = self.get_mut() {
+            Pin::new(stream).poll_flush(context)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, context: &mut Context) -> Poll<io::Result<()>> {
+        if let Self::Ready(stream) = self.get_mut() {
+            Pin::new(stream).poll_shutdown(context)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        context: &mut Context,
+        bufs: &[io::IoSlice],
+    ) -> Poll<io::Result<usize>> {
+        if let Self::Ready(stream) = self.get_mut() {
+            Pin::new(stream).poll_write_vectored(context, bufs)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl Future for Negotiate {
+    type Output = io::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        if let Self::Pending(accept) = this {
+            let stream = ready!(Pin::new(accept).poll(context)?);
+            *this = Negotiate::Ready(stream);
+        }
+
+        Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
Cleans up the TLS implementations by making the following changes:

- acceptor is Box<Fn()>, not Arc<Fn()> cloning happens when acceptor is called.
- rustls boxes the Accept future and reuses the box for the tls stream.
- IoWithPermit is generic over Read and Write rather than AsyncRead + AsyncWrite
- IoWithPermit uses a pin projection anytime a Pin<&mut T> is needed.

This keeps the risk of stack overflow extremely low for all http versions and each tls backend. The connection task size is always less than a kilobyte.
