### PR TITLE
fix(via): provide sensible defaults for ws middleware

### DIFF
--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -8,9 +8,10 @@ use std::task::{Context, Poll};
 
 use crate::error::BoxError;
 
-const STANDARD_FRAME_LEN: usize = 8 * 1024; // 8KB
-const EXTENDED_FRAME_LEN: usize = STANDARD_FRAME_LEN * 2; // 16KB
 const ADAPTIVE_THRESHOLD: usize = 64 * 1024; // 64KB
+
+pub(crate) const STANDARD_FRAME_LEN: usize = 8 * 1024; // 8KB
+pub(crate) const EXTENDED_FRAME_LEN: usize = STANDARD_FRAME_LEN * 2; // 16KB
 
 /// A buffered `impl Body` that is written in `8KB..=16KB` chunks.
 ///

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,10 +1,11 @@
-mod body;
 mod builder;
 mod redirect;
 mod response;
 
 #[cfg(feature = "file")]
 mod file;
+
+pub(crate) mod body;
 
 #[cfg(feature = "file")]
 pub use file::File;


### PR DESCRIPTION
Includes a default `max_payload_size` for the ws middleware that is equal to the flush threshold. Also documents the config methods on the `Upgrade` struct.