### PR TITLE
refactor(via): prefer ErrorKind to Either

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ ws = [
 
 [dependencies]
 bytes = "1"
-either = "1"
 futures-core = "0.3"
 http = "1"
 http-body = "1"


### PR DESCRIPTION
Use an `ErrorKind` enum rather than `Either` in the event that specialization lands before documentation is finished. Also prevents blanket impls from being added to every type in the public API.