### PR TITLE
chore(via): update via-router to v3.0.0-beta.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
 smallvec = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-via-router = { version = "3.0.0-beta.28" }
+via-router = { version = "3.0.0-beta.29" }
 
 [dependencies.aws-lc-rs]
 version = "1"

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -18,13 +18,16 @@ impl<State> App<State> {
         }
     }
 
-    pub fn middleware(&mut self, middleware: impl Middleware<State> + 'static) {
+    pub fn middleware<T>(&mut self, middleware: T)
+    where
+        T: Middleware<State> + 'static,
+    {
         self.route("/").middleware(middleware);
     }
 
     pub fn route(&mut self, path: &'static str) -> Route<'_, State> {
         Route {
-            inner: self.router.at(path),
+            inner: self.router.route(path),
         }
     }
 }

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -9,17 +9,23 @@ pub struct Route<'a, State> {
 }
 
 impl<State> Route<'_, State> {
-    pub fn middleware(&mut self, middleware: impl Middleware<State> + 'static) {
-        self.inner.include(Arc::new(middleware));
+    pub fn middleware<T>(&mut self, middleware: T)
+    where
+        T: Middleware<State> + 'static,
+    {
+        self.inner.middleware(Arc::new(middleware));
     }
 
-    pub fn respond(&mut self, middleware: impl Middleware<State> + 'static) {
+    pub fn respond<T>(&mut self, middleware: T)
+    where
+        T: Middleware<State> + 'static,
+    {
         self.inner.respond(Arc::new(middleware));
     }
 
     pub fn route(&mut self, path: &'static str) -> Route<'_, State> {
         Route {
-            inner: self.inner.at(path),
+            inner: self.inner.route(path),
         }
     }
 


### PR DESCRIPTION
Updates via-router to v3.0.0-beta.29. No functional changes, just some name changes to internal APIs.