### PR TITLE
feat(via): support untagged json response bodies

### DIFF
--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -11,6 +11,6 @@ pub(crate) mod body;
 pub use file::File;
 
 pub use body::ResponseBody;
-pub use builder::ResponseBuilder;
+pub use builder::{Json, ResponseBuilder};
 pub use redirect::Redirect;
 pub use response::Response;

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -78,6 +78,11 @@ impl Response {
         self.inner.extensions_mut()
     }
 
+    #[inline]
+    pub fn body(&self) -> &ResponseBody {
+        self.inner.body()
+    }
+
     /// Returns a reference to the response cookies.
     ///
     #[inline]


### PR DESCRIPTION
Adds support for untagged Json response bodies with the introduction of `via::response::Json` with a `Pipe` impl. Also lifts error responses out of the top-level data field of a response.


```rust
use serde::Serialize;
use via::{Pipe, Response};
use via::response::Json;

#[derive(Serialize)]
struct Cat {
    name: String,
}

let ciro = Cat {
    name: "Ciro".to_owned(),
};

let tagged = Response::build().json(&ciro).unwrap();
// => { "data": { "name": "Ciro" } }

let untagged = Json(&ciro).pipe(Response::build()).unwrap();
// => { "name": "Ciro" }
```