### PR TITLE
refactor(via): use BoxError less frequently

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Below is a basic example to demonstrate how to use Via to create a simple web se
 
 ```rust
 use std::process::ExitCode;
-use via::{App, BoxError, Next, Request, Response, Server};
+use via::{App, Error, Next, Request, Response, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result {
     // Get a reference to the path parameter `name` from the request uri.
@@ -36,7 +36,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     let mut app = App::new(());
 
     // Define a route that listens on /hello/:name.

--- a/examples/blog-api/src/database/mod.rs
+++ b/examples/blog-api/src/database/mod.rs
@@ -10,12 +10,12 @@ pub mod prelude {
 
 use diesel_async::{AsyncPgConnection, pooled_connection::AsyncDieselConnectionManager};
 use std::env;
-use via::BoxError;
+use via::Error;
 
 type ConnectionManager = AsyncDieselConnectionManager<AsyncPgConnection>;
 pub type Pool = bb8::Pool<ConnectionManager>;
 
-pub async fn pool() -> Result<Pool, BoxError> {
+pub async fn pool() -> Result<Pool, Error> {
     let config = ConnectionManager::new(env::var("DATABASE_URL")?);
     Ok(Pool::builder().build(config).await?)
 }

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -3,7 +3,7 @@ mod database;
 
 use std::process::ExitCode;
 use std::time::Duration;
-use via::{App, BoxError, Next, Request, Server, rescue, timeout};
+use via::{App, Error, Next, Request, Server, rescue, timeout};
 
 use api::util::with_error_sanitizer;
 use api::{posts, users};
@@ -14,7 +14,7 @@ struct BlogApi {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     dotenvy::dotenv()?;
 
     let mut app = App::new(BlogApi {

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -3,14 +3,14 @@ mod room;
 
 use http::header;
 use std::process::ExitCode;
-use via::{App, BoxError, Response, Server};
+use via::{App, Error, Response, Server};
 
 use crate::chat::Chat;
 
 const CSP: &str = "default-src 'self'; connect-src 'self'";
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     let mut app = App::new(Chat::new());
 
     app.route("/").respond(via::get(async |_, _| {

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,6 +1,6 @@
 use cookie::{Cookie, Key};
 use std::process::ExitCode;
-use via::{App, BoxError, Next, Request, Response, Server, cookies};
+use via::{App, Error, Next, Request, Response, Server, cookies};
 
 /// A struct used to store application state.
 ///
@@ -84,7 +84,7 @@ fn get_secret_from_env() -> Key {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     // Load the environment variables from the ".env" file. This is where we
     // keep the secret key in development. In production, you may want to
     // configure the secret key using a different method. For example, using

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -1,12 +1,12 @@
 use std::process::ExitCode;
-use via::{App, BoxError, Next, Pipe, Request, Response, Server};
+use via::{App, Error, Next, Pipe, Request, Response, Server};
 
 async fn echo(request: Request, _: Next) -> via::Result {
     request.pipe(Response::build())
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     let mut app = App::new(());
 
     // Add our echo responder to the endpoint /echo.

--- a/examples/file-server/src/main.rs
+++ b/examples/file-server/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 use via::response::File;
-use via::{App, BoxError, Next, Request, Server};
+use via::{App, Error, Next, Request, Server};
 
 /// The maximum amount of memory that will be allocated to serve a single file.
 ///
@@ -54,7 +54,7 @@ fn resolve_path(path_param: &str) -> PathBuf {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     let mut app = App::new(());
 
     // Serve any file located in the public dir.

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,5 +1,5 @@
 use std::process::ExitCode;
-use via::{App, BoxError, Next, Request, Response, Server};
+use via::{App, Error, Next, Request, Response, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result {
     // Get a reference to the path parameter `name` from the request uri.
@@ -10,7 +10,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     let mut app = App::new(());
 
     // Define a route that listens on /hello/:name.

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
-use via::{App, BoxError, Next, Request, Response, Server};
+use via::{App, Error, Next, Request, Response, Server};
 
 /// A struct of containing the shared state for the application. This struct
 /// will be made available to all middleware functions and responders by
@@ -69,7 +69,7 @@ async fn totals(request: Request<Counter>, _: Next<Counter>) -> via::Result {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     let mut app = App::new(Counter {
         errors: Arc::new(AtomicU32::new(0)),
         sucesses: Arc::new(AtomicU32::new(0)),

--- a/examples/tls-native/src/main.rs
+++ b/examples/tls-native/src/main.rs
@@ -1,9 +1,9 @@
 use native_tls::Identity;
 use std::process::ExitCode;
 use std::{env, fs};
-use via::{App, BoxError, Next, Request, Response, Server};
+use via::{App, Error, Next, Request, Response, Server};
 
-fn load_pkcs12() -> Result<Identity, BoxError> {
+fn load_pkcs12() -> Result<Identity, Error> {
     let identity = fs::read("localhost.p12").expect("failed to load pkcs#12 file");
     let password = env::var("TLS_PKCS_PASSWORD").expect("missing TLS_PKCS_PASSWORD in env");
 
@@ -19,7 +19,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     dotenvy::dotenv()?;
 
     // Make sure that our TLS config is present and valid before we proceed.

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -1,7 +1,7 @@
 mod tls;
 
 use std::process::ExitCode;
-use via::{App, BoxError, Next, Request, Response, Server};
+use via::{App, Error, Next, Request, Response, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result {
     // Get a reference to the path parameter `name` from the request uri.
@@ -12,7 +12,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, BoxError> {
+async fn main() -> Result<ExitCode, Error> {
     // Make sure that our TLS config is present and valid before we proceed.
     let tls_config = tls::server_config().expect("tls config is invalid or missing");
 

--- a/src/allow.rs
+++ b/src/allow.rs
@@ -14,7 +14,7 @@ use crate::{Next, Request, Response};
 ///
 /// ```no_run
 /// use std::process::ExitCode;
-/// use via::{App, BoxError, Server};
+/// use via::{App, Error, Server};
 ///
 /// mod users {
 ///     use via::{Next, Request};
@@ -27,7 +27,7 @@ use crate::{Next, Request, Response};
 /// }
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<ExitCode, BoxError> {
+/// async fn main() -> Result<ExitCode, Error> {
 ///     let mut app = App::new(());
 ///
 ///     // HTTP method based dispatch.

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -22,7 +22,7 @@ use crate::response::{Response, ResponseBody};
 pub use rescue::{Rescue, Sanitize, rescue};
 pub(crate) use server::ServerError;
 
-/// A type alias for a boxed `dyn Error + Send + Sync`.
+/// A type alias for `Box<dyn Error + Send + Sync>`.
 ///
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 

--- a/src/error/raise.rs
+++ b/src/error/raise.rs
@@ -233,4 +233,6 @@ macro_rules! raise {
     (511, $($arg:tt)*) => {
         $crate::raise!(@reason NETWORK_AUTHENTICATION_REQUIRED, $($arg)*)
     };
+
+    ($($arg:tt)*) => { $crate::raise!(500, $($arg)*) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```no_run
 //! use std::process::ExitCode;
-//! use via::{App, BoxError, Next, Request, Response, Server};
+//! use via::{App, Error, Next, Request, Response, Server};
 //!
 //! async fn hello(request: Request, _: Next) -> via::Result {
 //!     // Get a reference to the path parameter `name` from the request uri.
@@ -27,7 +27,7 @@
 //! }
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<ExitCode, BoxError> {
+//! async fn main() -> Result<ExitCode, Error> {
 //!     let mut app = App::new(());
 //!
 //!     // Define a route that listens on /hello/:name.
@@ -71,7 +71,7 @@ pub use server::Server;
 pub use timeout::{Timeout, timeout};
 
 #[doc(inline)]
-pub use error::{BoxError, rescue};
+pub use error::rescue;
 
 #[cfg(feature = "ws")]
 #[doc(inline)]

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use tokio::net::ToSocketAddrs;
 
 use crate::app::{App, AppService};
-use crate::error::BoxError;
+use crate::error::Error;
 
 #[cfg(any(feature = "native-tls", feature = "rustls"))]
 use super::tls;
@@ -136,7 +136,7 @@ where
     /// process supervisor of an individual node and the replacement and
     /// decommissioning logic of the cluster.
     ///
-    pub fn listen<A>(self, address: A) -> impl Future<Output = Result<ExitCode, BoxError>>
+    pub fn listen<A>(self, address: A) -> impl Future<Output = Result<ExitCode, Error>>
     where
         A: ToSocketAddrs,
     {
@@ -162,7 +162,7 @@ where
         self,
         address: A,
         tls_config: native_tls::Identity,
-    ) -> impl Future<Output = Result<ExitCode, BoxError>>
+    ) -> impl Future<Output = Result<ExitCode, Error>>
     where
         A: ToSocketAddrs,
     {
@@ -177,7 +177,7 @@ where
         self,
         address: A,
         tls_config: rustls::ServerConfig,
-    ) -> impl Future<Output = Result<ExitCode, BoxError>>
+    ) -> impl Future<Output = Result<ExitCode, Error>>
     where
         A: ToSocketAddrs,
     {

--- a/src/server/tls/native.rs
+++ b/src/server/tls/native.rs
@@ -7,7 +7,7 @@ use tokio_native_tls::TlsAcceptor;
 use super::super::accept;
 use super::super::server::ServerConfig;
 use crate::app::AppService;
-use crate::error::BoxError;
+use crate::error::Error;
 
 const MIN_PROTOCOL_VERSION: Protocol = Protocol::Tlsv12;
 
@@ -16,7 +16,7 @@ pub fn listen_native_tls<State, A>(
     address: A,
     identity: Identity,
     service: AppService<State>,
-) -> impl Future<Output = Result<ExitCode, BoxError>>
+) -> impl Future<Output = Result<ExitCode, Error>>
 where
     A: ToSocketAddrs,
     State: Send + Sync + 'static,

--- a/src/server/tls/rustls.rs
+++ b/src/server/tls/rustls.rs
@@ -11,7 +11,7 @@ use tokio_rustls::server::{Accept, TlsAcceptor, TlsStream};
 use super::super::accept;
 use super::super::server::ServerConfig;
 use crate::app::AppService;
-use crate::error::BoxError;
+use crate::error::Error;
 
 enum Negotiate {
     Ready(TlsStream<TcpStream>),
@@ -23,7 +23,7 @@ pub fn listen_rustls<State, A>(
     address: A,
     tls_config: rustls::ServerConfig,
     service: AppService<State>,
-) -> impl Future<Output = Result<ExitCode, BoxError>>
+) -> impl Future<Output = Result<ExitCode, Error>>
 where
     A: ToSocketAddrs,
     State: Send + Sync + 'static,

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -70,10 +70,10 @@ pub struct ValidUtf8 {
 ///
 /// ```
 /// use via::ws::{self, Message};
-/// use via::{App, BoxError, Payload};
+/// use via::{App, Error, Payload};
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<(), BoxError> {
+/// async fn main() -> Result<(), Error> {
 ///     let mut app = App::new(());
 ///
 ///     // GET /echo ~> web socket upgrade.


### PR DESCRIPTION
Since `Error` is less convoluted with rescue APIs, it can be used as a general purpose error type without feeling like it brings too much unnecessary context.

This PR refactors the listen functions of the `Server` type to return `Result<ExitCode, Error>`. The `BoxError` type alias is still available within the `via::error` module to make writing custom body implementations or streams more ergonomic.

Also, makes the status code argument to the raise macro optional.