### PR TITLE
refactor(via): prefer mutability in the rescue API

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -19,7 +19,7 @@ pub use http::StatusCode; // Required for the raise macro.
 
 use crate::response::{Response, ResponseBody};
 
-pub use rescue::{Rescue, Sanitize, rescue};
+pub use rescue::{Rescue, Sanitizer, rescue};
 pub(crate) use server::ServerError;
 
 /// A type alias for `Box<dyn Error + Send + Sync>`.

--- a/src/error/rescue.rs
+++ b/src/error/rescue.rs
@@ -15,7 +15,7 @@ pub struct Rescue<F> {
 
 /// Customize how an [`Error`] is converted to a response.
 ///
-pub struct Sanitize<'a> {
+pub struct Sanitizer<'a> {
     json: bool,
     error: &'a Error,
     status: Option<StatusCode>,
@@ -26,7 +26,7 @@ pub struct Sanitize<'a> {
 ///
 pub fn rescue<F>(recover: F) -> Rescue<F>
 where
-    F: Fn(Sanitize) -> Sanitize + Copy + Send + Sync + 'static,
+    F: Fn(&mut Sanitizer) + Copy + Send + Sync + 'static,
 {
     Rescue { recover }
 }
@@ -34,7 +34,7 @@ where
 impl<State, F> Middleware<State> for Rescue<F>
 where
     State: Send + Sync + 'static,
-    F: Fn(Sanitize) -> Sanitize + Copy + Send + Sync + 'static,
+    F: Fn(&mut Sanitizer) + Copy + Send + Sync + 'static,
 {
     fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture {
         let Self { recover } = *self;
@@ -42,9 +42,10 @@ where
         Box::pin(async move {
             next.call(request).await.or_else(|error| {
                 let response = Response::build();
-                let sanitize = Sanitize::new(&error);
+                let mut sanitizer = Sanitizer::new(&error);
 
-                recover(sanitize).pipe(response).or_else(|residual| {
+                recover(&mut sanitizer);
+                sanitizer.pipe(response).or_else(|residual| {
                     if cfg!(debug_assertions) {
                         eprintln!("warn: a residual error occurred in rescue");
                         eprintln!("{}", residual);
@@ -57,59 +58,47 @@ where
     }
 }
 
-impl<'a> Sanitize<'a> {
+impl<'a> Sanitizer<'a> {
+    /// Returns a reference to the error source.
+    ///
+    pub fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.error.source()
+    }
+
     /// Generate a json response for the error.
     ///
-    pub fn as_json(self) -> Self {
-        Self { json: true, ..self }
-    }
-
-    /// Sanitize the contained error based on the error source.
-    ///
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: FnOnce(Self, &(dyn std::error::Error + 'static)) -> Self,
-    {
-        if let Some(source) = self.error.source() {
-            f(self, source)
-        } else {
-            self
-        }
-    }
-
-    /// Use the canonical reason of the status code as the error message.
-    ///
-    pub fn with_canonical_reason(self) -> Self {
-        Self {
-            message: self.status_code().canonical_reason().map(Cow::Borrowed),
-            ..self
-        }
+    pub fn respond_with_json(&mut self) -> &mut Self {
+        self.json = true;
+        self
     }
 
     /// Provide a custom message to use for the response generated from this
     /// error.
     ///
-    pub fn with_message<T>(self, message: T) -> Self
+    pub fn set_message<T>(&mut self, message: T) -> &mut Self
     where
         Cow<'a, str>: From<T>,
     {
-        Self {
-            message: Some(message.into()),
-            ..self
-        }
+        self.message = Some(message.into());
+        self
     }
 
     /// Overrides the HTTP status code of the error.
     ///
-    pub fn with_status_code(self, status: StatusCode) -> Self {
-        Self {
-            status: Some(status),
-            ..self
-        }
+    pub fn set_status_code(&mut self, status: StatusCode) -> &mut Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Use the canonical reason of the status code as the error message.
+    ///
+    pub fn use_canonical_reason(&mut self) -> &mut Self {
+        self.message = self.status_code().canonical_reason().map(Cow::Borrowed);
+        self
     }
 }
 
-impl<'a> Sanitize<'a> {
+impl<'a> Sanitizer<'a> {
     fn new(error: &'a Error) -> Self {
         Self {
             json: false,
@@ -124,13 +113,13 @@ impl<'a> Sanitize<'a> {
     }
 }
 
-impl Display for Sanitize<'_> {
+impl Display for Sanitizer<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self.error, f)
     }
 }
 
-impl Pipe for Sanitize<'_> {
+impl Pipe for Sanitizer<'_> {
     fn pipe(self, response: ResponseBuilder) -> Result<Response, Error> {
         let status_code = self.status_code();
         let response = response.status(status_code);


### PR DESCRIPTION
A mutable API makes the most sense for the error sanitizer. Error handling logic is often times branchy, making it harder to chain function the way you would when using the builder pattern.

This should conclude any change that could be considered a breaking change. Expect PRs for documentation, additive changes, and tracing leading up to the next official release.