### PR TITLE
refactor(via): ergonomic improvements to Rescue middleware

### DIFF
--- a/examples/blog-api/src/api/util.rs
+++ b/examples/blog-api/src/api/util.rs
@@ -2,14 +2,13 @@ use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use http::StatusCode;
 use via::error::Sanitizer;
 
-/// Sanitizes details about database errors that
-pub fn with_error_sanitizer(sanitizer: &mut Sanitizer) {
+pub fn error_sanitizer(sanitizer: &mut Sanitizer) {
     // Print the original message to stderr. In production you probably want
     // to use env_logger, tracing, or something similar.
     eprintln!("error: {}", sanitizer);
 
     // Configure the sanitizer to generate a JSON response.
-    sanitizer.respond_with_json();
+    sanitizer.use_json();
 
     // If the error occurred during a database operation, set the appropriate
     // status code or obsfuscate the message depending on the nature of the

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -3,10 +3,10 @@ mod database;
 
 use std::process::ExitCode;
 use std::time::Duration;
-use via::{App, Error, Next, Request, Server, rescue, timeout};
+use via::error::{Error, Rescue};
+use via::{App, Next, Request, Server, timeout};
 
-use api::util::with_error_sanitizer;
-use api::{posts, users};
+use api::{posts, users, util};
 use database::Pool;
 
 struct BlogApi {
@@ -39,7 +39,7 @@ async fn main() -> Result<ExitCode, Error> {
     // Capture errors that occur in the api namespace, log them, and then
     // convert them into json responses. Upstream middleware remains
     // unaffected and continues execution.
-    api.middleware(rescue(with_error_sanitizer));
+    api.middleware(Rescue::with(util::error_sanitizer));
 
     // Add a timeout middleware to the /api routes. This will prevent the
     // server from waiting indefinitely if we lose connection to the

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -19,7 +19,7 @@ pub use http::StatusCode; // Required for the raise macro.
 
 use crate::response::{Response, ResponseBody};
 
-pub use rescue::{Rescue, Sanitizer, rescue};
+pub use rescue::{Rescue, Sanitizer};
 pub(crate) use server::ServerError;
 
 /// A type alias for `Box<dyn Error + Send + Sync>`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,6 @@ pub use response::Response;
 pub use server::Server;
 pub use timeout::{Timeout, timeout};
 
-#[doc(inline)]
-pub use error::rescue;
-
 #[cfg(feature = "ws")]
 #[doc(inline)]
 pub use ws::ws;


### PR DESCRIPTION
Paradoxically improves the ergonomics of the `Rescue` middleware by not returning `&mut Self` from the methods exposed by the `Sanitizer` API.

The `Sanitizer` API uses mutability rather than the builder pattern. Returning `&mut Self` from the setters on `impl Sanitizer` encourages an anti-pattern. This change makes the assertion made in #300 an explicit part of the way `Sanitizer` works.