### PR TITLE
refactor(via): CookieParser ~> Cookies + improvements

### DIFF
--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -76,11 +76,12 @@ impl<State> Route<'_, State> {
     /// # Example
     ///
     /// ```
+    /// # use via::cookies::Cookies;
     /// # use via::{App, Request, Next, raise};
     /// # let mut app = App::new(());
     /// #
     /// // Provides application-wide support for request and response cookies.
-    /// app.middleware(via::cookies::unencoded());
+    /// app.middleware(Cookies::unencoded());
     ///
     /// // Requests made to /admin or any of its descendants must have an
     /// // is_admin cookie present on the request.

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,73 +1,92 @@
-use cookie::{Cookie, SplitCookies};
-use http::header::COOKIE;
+use cookie::Cookie;
+use http::HeaderValue;
+use http::header::{COOKIE, SET_COOKIE};
 
-use crate::Next;
 use crate::middleware::{BoxFuture, Middleware};
 use crate::request::{Request, RequestHead};
 use crate::util::UriEncoding;
+use crate::{Error, Next, raise};
 
 #[derive(Debug)]
-pub struct CookieParser(UriEncoding);
-
-pub fn percent_decode() -> CookieParser {
-    CookieParser(UriEncoding::Percent)
+pub struct Cookies {
+    codec: UriEncoding,
 }
 
-pub fn unencoded() -> CookieParser {
-    CookieParser(UriEncoding::Unencoded)
+fn encode_set_cookie_header(codec: &UriEncoding, cookie: &Cookie) -> Result<HeaderValue, Error> {
+    Ok(match codec {
+        UriEncoding::Percent => cookie.encoded().to_string().try_into()?,
+        UriEncoding::Unencoded => cookie.to_string().try_into()?,
+    })
 }
 
-impl CookieParser {
-    fn parse(&self, input: String) -> SplitCookies<'static> {
-        match self.0 {
-            UriEncoding::Percent => Cookie::split_parse_encoded(input),
-            UriEncoding::Unencoded => Cookie::split_parse(input),
+fn parse_cookie_header<State>(
+    request: &mut Request<State>,
+    codec: &UriEncoding,
+) -> Result<Vec<Cookie<'static>>, Error> {
+    let mut results = {
+        let Some(input) = request.header(COOKIE)? else {
+            return Ok(vec![]);
+        };
+
+        match codec {
+            UriEncoding::Percent => Cookie::split_parse_encoded(input.to_owned()),
+            UriEncoding::Unencoded => Cookie::split_parse(input.to_owned()),
         }
+    };
+
+    let RequestHead { cookies, .. } = request.head_mut();
+    let mut existing = Vec::new();
+
+    for result in &mut results {
+        match result {
+            Ok(cookie) => {
+                existing.push(cookie.clone());
+                cookies.add_original(cookie);
+            }
+            Err(error) => {
+                return Err(raise!(400, error));
+            }
+        }
+    }
+
+    Ok(existing)
+}
+
+impl Cookies {
+    fn new(codec: UriEncoding) -> Self {
+        Self { codec }
+    }
+
+    pub fn percent_decode() -> Self {
+        Self::new(UriEncoding::Percent)
+    }
+
+    pub fn unencoded() -> Self {
+        Self::new(UriEncoding::Unencoded)
     }
 }
 
-impl<State> Middleware<State> for CookieParser
+impl<State> Middleware<State> for Cookies
 where
     State: Send + Sync + 'static,
 {
     fn call(&self, mut request: Request<State>, next: Next<State>) -> BoxFuture {
-        let Self(codec) = *self;
-        let parse_result = 'parse: {
-            let mut existing = Vec::new();
-            let input = match request.header(COOKIE) {
-                Ok(Some(str)) => str.to_owned(),
-                Err(error) => break 'parse Err(error),
-                Ok(None) => break 'parse Ok(existing),
-            };
-
-            let RequestHead { cookies, .. } = request.head_mut();
-
-            for result in self.parse(input) {
-                match result {
-                    Err(error) => break 'parse Err(crate::raise!(400, error)),
-                    Ok(cookie) => {
-                        existing.push(cookie.clone());
-                        cookies.add_original(cookie);
-                    }
-                }
-            }
-
-            Ok(existing)
-        };
+        let Self { codec } = *self;
+        let result = parse_cookie_header(&mut request, &codec);
 
         Box::pin(async move {
-            let existing = parse_result?;
+            let existing = result?;
             let mut response = next.call(request).await?;
+            let (cookies, headers) = response.cookies_and_headers_mut();
 
-            let jar = response.cookies_mut();
             for cookie in existing {
-                jar.add_original(cookie);
+                cookies.add_original(cookie);
             }
 
-            response.set_cookies(|cookie| match codec {
-                UriEncoding::Percent => cookie.encoded().to_string(),
-                UriEncoding::Unencoded => cookie.to_string(),
-            })?;
+            for cookie in cookies.delta() {
+                let set_cookie = encode_set_cookie_header(&codec, cookie)?;
+                headers.try_append(SET_COOKIE, set_cookie)?;
+            }
 
             Ok(response)
         })

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -1,13 +1,12 @@
 use bytes::Bytes;
-use cookie::{Cookie, CookieJar};
-use http::header::SET_COOKIE;
+use cookie::CookieJar;
 use http::{Extensions, HeaderMap, StatusCode, Version};
 use http_body::Body;
 use std::fmt::{self, Debug, Formatter};
 
 use super::body::ResponseBody;
 use super::builder::ResponseBuilder;
-use crate::error::{BoxError, Error};
+use crate::error::BoxError;
 
 pub struct Response {
     pub(super) cookies: CookieJar,
@@ -99,17 +98,9 @@ impl Response {
 }
 
 impl Response {
-    pub(crate) fn set_cookies<F>(&mut self, f: F) -> Result<(), Error>
-    where
-        F: Fn(&Cookie) -> String,
-    {
-        let headers = self.inner.headers_mut();
-
-        for cookie in self.cookies.delta() {
-            headers.try_append(SET_COOKIE, f(cookie).parse()?)?;
-        }
-
-        Ok(())
+    pub(crate) fn cookies_and_headers_mut(&mut self) -> (&mut CookieJar, &mut HeaderMap) {
+        let Self { cookies, inner } = self;
+        (cookies, inner.headers_mut())
     }
 }
 


### PR DESCRIPTION
Improves control flow in the cookies middleware. Also changes the name of the middleware from `CookieParser` to `Cookies`.