### PR TITLE
feat(via): provide Finalize::into_response

### DIFF
--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -1,9 +1,9 @@
 use std::process::ExitCode;
-use via::response::{Finalize, Response};
+use via::response::Finalize;
 use via::{App, Error, Next, Request, Server};
 
 async fn echo(request: Request, _: Next) -> via::Result {
-    request.finalize(Response::build())
+    request.into_response()
 }
 
 #[tokio::main]

--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -33,7 +33,7 @@ pub(super) const MAX_FRAME_SIZE: usize = 16 * 1024; // 16KB
 /// let tagged = Response::build().json(&ciro).unwrap();
 /// // => { "data": { "name": "Ciro" } }
 ///
-/// let untagged = Json(&ciro).finalize(Response::build()).unwrap();
+/// let untagged = Json(&ciro).into_response().unwrap();
 /// // => { "name": "Ciro" }
 /// ```
 ///
@@ -120,7 +120,10 @@ impl From<&'_ [u8]> for BufferBody {
     }
 }
 
-impl<'a, T: Serialize> Finalize for Json<'a, T> {
+impl<'a, T> Finalize for Json<'a, T>
+where
+    T: Serialize,
+{
     #[inline]
     fn finalize(self, response: ResponseBuilder) -> Result<Response, Error> {
         let Self(json) = self;

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -23,8 +23,13 @@ use crate::error::{BoxError, Error};
 /// }
 /// ```
 ///
-pub trait Finalize {
-    fn finalize(self, response: ResponseBuilder) -> Result<Response, Error>;
+pub trait Finalize: Sized {
+    fn finalize(self, builder: ResponseBuilder) -> Result<Response, Error>;
+
+    #[inline]
+    fn into_response(self) -> Result<Response, Error> {
+        self.finalize(Default::default())
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
Provides an `into_response` method for any type that implements `Finalize`. This provides a convenient alternative to passing an empty response builder to `Finalize::finalize`. See also #310 for an explanation as to why we will never implicitly call `into_response` on a users behalf.

```rust
use std::process::ExitCode;
use via::response::Finalize;
use via::{App, Error, Next, Request, Server};

async fn echo(request: Request, _: Next) -> via::Result {
    request.into_response()
}

#[tokio::main]
async fn main() -> Result<ExitCode, Error> {
    let mut app = App::new(());
    
    app.route("/echo").respond(via::get(echo));
    
    Server::new(app).listen(("127.0.0.1", 8080)).await
}
```