### PR TITLE
feat(via): provide a RequestHead::into_state fn

### DIFF
--- a/examples/blog-api/src/api/posts.rs
+++ b/examples/blog-api/src/api/posts.rs
@@ -1,3 +1,4 @@
+use http::StatusCode;
 use via::{Next, Payload, Request, Response};
 
 use crate::BlogApi;
@@ -9,7 +10,7 @@ pub async fn auth(request: Request<BlogApi>, next: Next<BlogApi>) -> via::Result
 }
 
 pub async fn index(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
-    let state = request.state();
+    let state = request.state().as_ref();
     let posts = Post::public(&state.pool).await?;
 
     Response::build().json(&posts)
@@ -17,38 +18,41 @@ pub async fn index(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
 
 pub async fn create(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let (head, body) = request.into_parts();
-    let state = head.state();
+    let state = head.into_state();
 
-    let new_post = body.into_future().await?.parse_json::<NewPost>()?;
-    let post = new_post.insert(&state.pool).await?;
+    let post_params = body.into_future().await?.parse_json::<NewPost>()?;
+    let new_post = post_params.insert(&state.pool).await?;
 
-    Response::build().status(201).json(&post)
+    Response::build()
+        .status(StatusCode::CREATED)
+        .json(&new_post)
 }
 
 pub async fn show(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
-    let state = request.state();
     let id = request.param("id").parse()?;
+    let state = request.state().as_ref();
+    let post_by_id = Post::find(&state.pool, id).await?;
 
-    let post = Post::find(&state.pool, id).await?;
-
-    Response::build().json(&post)
+    Response::build().json(&post_by_id)
 }
 
 pub async fn update(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
+    let id = request.param("id").parse()?;
+
     let (head, body) = request.into_parts();
-    let state = head.state();
-    let id = head.param("id").parse()?;
+    let state = head.into_state();
 
     let change_set = body.into_future().await?.parse_json::<ChangeSet>()?;
-    let post = change_set.apply(&state.pool, id).await?;
+    let updated_post = change_set.apply(&state.pool, id).await?;
 
-    Response::build().json(&post)
+    Response::build().json(&updated_post)
 }
 
 pub async fn destroy(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
-    let state = request.state();
     let id = request.param("id").parse()?;
 
+    let state = request.state().as_ref();
     Post::delete(&state.pool, id).await?;
-    Response::build().status(204).finish()
+
+    Response::build().status(StatusCode::NO_CONTENT).finish()
 }

--- a/examples/blog-api/src/api/users.rs
+++ b/examples/blog-api/src/api/users.rs
@@ -1,10 +1,11 @@
+use http::StatusCode;
 use via::{Next, Payload, Request, Response};
 
 use crate::BlogApi;
 use crate::database::models::user::*;
 
 pub async fn index(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
-    let state = request.state();
+    let state = request.state().as_ref();
     let users = User::all(&state.pool).await?;
 
     Response::build().json(&users)
@@ -12,38 +13,40 @@ pub async fn index(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
 
 pub async fn create(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
     let (head, body) = request.into_parts();
-    let state = head.state();
+    let state = head.into_state();
 
-    let new_user = body.into_future().await?.parse_json::<NewUser>()?;
-    let user = new_user.insert(&state.pool).await?;
+    let user_params = body.into_future().await?.parse_json::<NewUser>()?;
+    let new_user = user_params.insert(&state.pool).await?;
 
-    Response::build().status(201).json(&user)
+    Response::build()
+        .status(StatusCode::CREATED)
+        .json(&new_user)
 }
 
 pub async fn show(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
-    let state = request.state();
     let id = request.param("id").parse()?;
+    let state = request.state().as_ref();
+    let user_by_id = User::find(&state.pool, id).await?;
 
-    let user = User::find(&state.pool, id).await?;
-
-    Response::build().json(&user)
+    Response::build().json(&user_by_id)
 }
 
 pub async fn update(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
+    let id = request.param("id").parse()?;
+
     let (head, body) = request.into_parts();
-    let state = head.state();
-    let id = head.param("id").parse()?;
+    let state = head.into_state();
 
     let change_set = body.into_future().await?.parse_json::<ChangeSet>()?;
-    let user = change_set.apply(&state.pool, id).await?;
+    let updated_user = change_set.apply(&state.pool, id).await?;
 
-    Response::build().json(&user)
+    Response::build().json(&updated_user)
 }
 
 pub async fn destroy(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result {
-    let state = request.state();
     let id = request.param("id").parse()?;
+    let state = request.state().as_ref();
 
     User::delete(&state.pool, id).await?;
-    Response::build().status(204).finish()
+    Response::build().status(StatusCode::NO_CONTENT).finish()
 }

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -233,6 +233,14 @@ impl<State> RequestHead<State> {
         }
     }
 
+    /// Consume the request head returning an arc to the state argument that
+    /// was passed to [`App::new`](crate::App::new).
+    ///
+    #[inline]
+    pub fn into_state(self) -> Arc<State> {
+        self.state
+    }
+
     /// Returns a reference to the request's method.
     ///
     #[inline]


### PR DESCRIPTION
Introduces a way to consume a `RequestHead` by moving state out of self. This method helps keep the fields of `RequestHead` live, only for as long as they are needed.

For example, it is often times desirable to use `request.state()` after reading a `RequestBody` in order to insert or update a row in a database table. This can now be achieved with as little waste as possible.

```rust
use bb8::Pool;
use diesel_async::AsyncPgConnection;
use diesel_async::pooled_connection::AsyncDieselConnectionManager;

struct Unicorn {
    pool: Pool<AsyncDieselConnectionManager<AsyncPgConnection>>,
}

pub async fn update(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
    let id = request.param("id").parse()?;

    let (head, body) = request.into_parts();
    let state /* : Arc<Unicorn> */ = head.into_state();

    // Insert row and respond with JSON...

    todo!()
}
```