### PR TITLE
refactor(via): rename parse_json ~> serde_json

### DIFF
--- a/examples/blog-api/src/api/posts.rs
+++ b/examples/blog-api/src/api/posts.rs
@@ -20,7 +20,7 @@ pub async fn create(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result 
     let (head, body) = request.into_parts();
     let state = head.into_state();
 
-    let post_params = body.into_future().await?.deserialize_json::<NewPost>()?;
+    let post_params = body.into_future().await?.serde_json::<NewPost>()?;
     let new_post = post_params.insert(&state.pool).await?;
 
     Response::build()
@@ -42,7 +42,7 @@ pub async fn update(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result 
     let (head, body) = request.into_parts();
     let state = head.into_state();
 
-    let change_set = body.into_future().await?.deserialize_json::<ChangeSet>()?;
+    let change_set = body.into_future().await?.serde_json::<ChangeSet>()?;
     let updated_post = change_set.apply(&state.pool, id).await?;
 
     Response::build().json(&updated_post)

--- a/examples/blog-api/src/api/users.rs
+++ b/examples/blog-api/src/api/users.rs
@@ -15,7 +15,7 @@ pub async fn create(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result 
     let (head, body) = request.into_parts();
     let state = head.into_state();
 
-    let user_params = body.into_future().await?.deserialize_json::<NewUser>()?;
+    let user_params = body.into_future().await?.serde_json::<NewUser>()?;
     let new_user = user_params.insert(&state.pool).await?;
 
     Response::build()
@@ -37,7 +37,7 @@ pub async fn update(request: Request<BlogApi>, _: Next<BlogApi>) -> via::Result 
     let (head, body) = request.into_parts();
     let state = head.into_state();
 
-    let change_set = body.into_future().await?.deserialize_json::<ChangeSet>()?;
+    let change_set = body.into_future().await?.serde_json::<ChangeSet>()?;
     let updated_user = change_set.apply(&state.pool, id).await?;
 
     Response::build().json(&updated_user)

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -149,7 +149,7 @@ struct SetCookieError;
 ///     let (head, body) = request.into_parts();
 ///     let state = head.into_state();
 ///
-///     let params = body.into_future().await?.deserialize_json::<Login>()?;
+///     let params = body.into_future().await?.serde_json::<Login>()?;
 ///
 ///     // Insert username and password verification here...
 ///     // For now, we'll just assert that the password is not empty.

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -11,6 +11,22 @@ pub trait Payload: Sized {
     ///
     fn copy_to_bytes(self) -> Bytes;
 
+    /// Copy the bytes in self into an owned, contiguous `String`.
+    ///
+    /// # Errors
+    ///
+    /// If the payload is not valid `UTF-8`.
+    ///
+    fn into_utf8(self) -> Result<String, Error> {
+        String::from_utf8(self.into_vec()).or_else(|error| raise!(400, error))
+    }
+
+    /// Copy the bytes in self into a contiguous `Vec<u8>`.
+    ///
+    fn into_vec(self) -> Vec<u8> {
+        self.copy_to_bytes().into()
+    }
+
     /// Deserialize and extract `T` as JSON from the top-level data field of
     /// the object contained by the bytes in self.
     ///
@@ -27,13 +43,13 @@ pub trait Payload: Sized {
     /// }
     ///
     /// let mut payload = Bytes::copy_from_slice(b"{\"data\":{\"name\":\"Ciro\"}}");
-    /// let cat = payload.deserialize_json::<Cat>().expect("invalid payload");
+    /// let cat = payload.serde_json::<Cat>().expect("invalid payload");
     ///
     /// println!("Meow, {}!", cat.name);
     /// // => Meow, Ciro!
     /// ```
     ///
-    fn deserialize_json<T>(self) -> Result<T, Error>
+    fn serde_json<T>(self) -> Result<T, Error>
     where
         T: DeserializeOwned,
     {
@@ -42,7 +58,7 @@ pub trait Payload: Sized {
             data: D,
         }
 
-        self.deserialize_untagged_json().map(|Json { data }| data)
+        self.serde_json_untagged().map(|Json { data }| data)
     }
 
     /// Deserialize type `T` as JSON from the bytes in self.
@@ -69,33 +85,17 @@ pub trait Payload: Sized {
     /// }
     ///
     /// let mut payload = Bytes::copy_from_slice(b"{\"name\":\"Ciro\"}");
-    /// let cat = payload.deserialize_untagged_json::<Cat>().expect("invalid payload");
+    /// let cat = payload.serde_json_untagged::<Cat>().expect("invalid payload");
     ///
     /// println!("Meow, {}!", cat.name);
     /// // => Meow, Ciro!
     /// ```
     ///
-    fn deserialize_untagged_json<T>(self) -> Result<T, Error>
+    fn serde_json_untagged<T>(self) -> Result<T, Error>
     where
         T: DeserializeOwned,
     {
         deserialize_json(&self.copy_to_bytes())
-    }
-
-    /// Copy the bytes in self into an owned, contiguous `String`.
-    ///
-    /// # Errors
-    ///
-    /// If the payload is not valid `UTF-8`.
-    ///
-    fn into_utf8(self) -> Result<String, Error> {
-        String::from_utf8(self.into_vec()).or_else(|error| raise!(400, error))
-    }
-
-    /// Copy the bytes in self into a contiguous `Vec<u8>`.
-    ///
-    fn into_vec(self) -> Vec<u8> {
-        self.copy_to_bytes().into()
     }
 }
 

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -337,7 +337,7 @@ impl Payload for Message {
         }
     }
 
-    fn deserialize_untagged_json<T>(mut self) -> Result<T, Error>
+    fn serde_json_untagged<T>(mut self) -> Result<T, Error>
     where
         T: DeserializeOwned,
     {


### PR DESCRIPTION
Uses a more meaningful name to rust developers than `parse_json`. I was contemplating what I would expect to see if I was learning to use the framework and naming the function `serde_json` seems like the most descriptive and syntactically balanced choice.