### PR TITLE
feat(via): BoxFuture is public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use allow::{Allow, connect, delete, get, head, options, patch, post, put, tr
 pub use app::{App, Route};
 pub use cookies::Cookies;
 pub use error::Error;
-pub use middleware::{Middleware, Result};
+pub use middleware::{BoxFuture, Middleware, Result};
 pub use next::Next;
 pub use payload::Payload;
 pub use request::Request;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -6,21 +6,27 @@ use crate::error::Error;
 use crate::request::Request;
 use crate::response::Response;
 
-/// The output of the `Future` returned from middleware.
+/// An alias for the pin
+/// [`Box<dyn Future>`]
+/// returned by
+/// [middleware](Middleware::call).
+///
+pub type BoxFuture<T = Result> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+/// An alias for results that uses the [`Error`] struct defined in this crate.
 ///
 pub type Result<T = Response> = std::result::Result<T, Error>;
-pub type BoxFuture<T = Result> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 
-pub trait Middleware<T>: Send + Sync {
-    fn call(&self, request: Request<T>, next: Next<T>) -> BoxFuture;
+pub trait Middleware<State>: Send + Sync {
+    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture;
 }
 
-impl<M, T, F> Middleware<T> for M
+impl<State, F, R> Middleware<State> for F
 where
-    M: Fn(Request<T>, Next<T>) -> F + Send + Sync,
-    F: Future<Output = Result> + Send + 'static,
+    F: Fn(Request<State>, Next<State>) -> R + Send + Sync,
+    R: Future<Output = Result> + Send + 'static,
 {
-    fn call(&self, request: Request<T>, next: Next<T>) -> BoxFuture {
+    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture {
         Box::pin(self(request, next))
     }
 }


### PR DESCRIPTION
The future type returned from middleware can become a bit verbose. These types aliases make a huge difference in readability of the code in this repo and likely have the same impact for other users. It also makes the docs for middleware less visually busy.

<img width="986" height="143" alt="Screenshot 2025-10-29 alle 4 14 26 PM" src="https://github.com/user-attachments/assets/e731f2e7-6207-4352-b418-b5d3a7fe9658" />
