### PR TITLE
refactor(via): sunset err! macro before it is too late

### DIFF
--- a/examples/tls-rustls/src/tls.rs
+++ b/examples/tls-rustls/src/tls.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use tokio_rustls::rustls;
-use via::{Error, err};
+use via::{Error, raise};
 
 /// Load the certificate and private key from the file system and use them
 /// to create a rustls::ServerConfig.
@@ -37,5 +37,11 @@ fn load_key(path: impl AsRef<Path>) -> Result<PrivateKeyDer<'static>, Error> {
 
     rustls_pemfile::private_key(&mut reader)
         .map_err(|error| error.into())
-        .and_then(|option| option.ok_or_else(|| err!(message = "failed to load private key")))
+        .and_then(|option| {
+            let Some(key) = option else {
+                raise!(message = "failed to load private key");
+            };
+
+            Ok(key)
+        })
 }

--- a/src/error/raise.rs
+++ b/src/error/raise.rs
@@ -1,12 +1,23 @@
-/// Create a new error or decorate an existing one.
+/// Return with a new error or decorate an existing one.
 ///
 /// # Examples
 ///
-/// Create a new error that uses the canonical reason prase of the provided
+/// Return an error that uses the canonical reason prase of the provided
 /// status code.
 ///
 /// ```
-/// via::err!(500);
+/// use http::header::AUTHORIZATION;
+/// use via::{Next, Request};
+///
+/// async fn authenticate(request: Request, next: Next) -> via::Result {
+///     let Some(jwt) = request.header(AUTHORIZATION)? else {
+///         via::raise!(401, message = "Missing required header: Authorization.");
+///     };
+///
+///     // Insert JWT-based authentication strategy here.
+///
+///     next.call(request).await
+/// }
 /// ```
 ///
 /// ### Decorate an existing error.
@@ -21,138 +32,108 @@
 ///
 /// ```
 /// use std::io;
-/// use via::err;
+/// use via::raise;
 ///
 /// fn invalid_input() -> io::Result<()> {
 ///     Err(io::ErrorKind::InvalidInput.into())
 /// }
 ///
 /// // Unboxed error types are passed as the second positional argument.
-/// invalid_input().map_err(|error| err!(400, error));
+/// # fn implicit_box() -> via::Result<()> {
+/// invalid_input().or_else(|error| raise!(400, error))?;
+/// # Ok(())
+/// # }
 ///
+/// # fn explicit_box() -> via::Result<()> {
 /// // If the error source is already boxed, specify so to avoid allocating.
-/// invalid_input().map_err(|error| err!(400, boxed = Box::new(error)));
+/// invalid_input().or_else(|error| raise!(400, boxed = Box::new(error)))?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// ### Customizing the error message.
 ///
-/// The `err!` macro also allows you to provide a custom error message. The
+/// The `raise!` macro also allows you to provide a custom error message. The
 /// message argument accepts `impl Into<String>`. Passing an owned `String` is
 /// no less efficient than passing a `message = &'static str`.
 ///
 /// ```
+/// # use via::raise;
 /// // Implicit allocation for message:
-/// via::err!(404, message = "Could not find a user with the provided id.");
+/// # fn implicit_alloc() -> via::Result {
+/// raise!(404, message = "Could not find a user with the provided id.");
+/// # }
 ///
 /// // Explicit allocation for message:
-/// via::err!(404, message = format!("User with id: {} does not exist.", 12345));
-/// ```
-///
-#[macro_export]
-macro_rules! err {
-    (message = $message:expr $(,)?) => { $crate::err!(500, message = $message) };
-    (boxed = $source:expr $(,)?) => { $crate::err!(500, boxed = $source) };
-    ($($args:tt)*) => { $crate::__via_impl_err!($($args)*) };
-}
-
-/// Wrap the output of `err!` in a result and return early.
-///
-/// # Example
-///
-/// ```
-/// use http::header::AUTHORIZATION;
-/// use via::{Next, Request, raise};
-///
-/// async fn authenticate(request: Request, next: Next) -> via::Result {
-///     let Some(jwt) = request.header(AUTHORIZATION)? else {
-///         raise!(401, message = "Missing required header: Authorization.")
-///     };
-///
-///     // Insert JWT-based authentication strategy here.
-///
-///     next.call(request).await
-/// }
+/// # fn explicit_alloc() -> via::Result {
+/// raise!(404, message = format!("User with id: {} does not exist.", 12345));
+/// # }
 /// ```
 ///
 #[macro_export]
 macro_rules! raise {
-    ($($args:tt)*) => { return Err($crate::err!($($args)*)) };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __via_impl_err {
-    /*
-     * Error constructor delegation
-     */
     (@ctor $status:expr, message = $message:expr $(,)?) => {
-        $crate::Error::new($status, $message)
+        return Err($crate::Error::new($status, $message))
     };
     (@ctor $status:expr, boxed = $source:expr $(,)?) => {
-        $crate::Error::from_source($status, $source)
+        return Err($crate::Error::from_source($status, $source))
     };
     (@ctor $status:expr, $source:expr $(,)?) => {
-        $crate::Error::from_source($status, Box::new($source))
+        return Err($crate::Error::from_source($status, Box::new($source)))
     };
     (@ctor $status:expr) => {{
         let status = $status;
         let message = status.canonical_reason().unwrap_or_default().to_owned();
-        $crate::Error::new(status, message)
+        return Err($crate::Error::new(status, message))
     }};
 
-    /*
-     * Expand a status identifier to an expr using a fully-qualified path.
-     */
+    (boxed = $source:expr $(,)?) => { $crate::raise!(500, boxed = $source) };
+    (message = $message:expr $(,)?) => { $crate::raise!(500, message = $message) };
+
+    (400 $($args:tt)*) => { $crate::raise!(BAD_REQUEST $($args)*) };
+    (401 $($args:tt)*) => { $crate::raise!(UNAUTHORIZED $($args)*) };
+    (402 $($args:tt)*) => { $crate::raise!(PAYMENT_REQUIRED $($args)*) };
+    (403 $($args:tt)*) => { $crate::raise!(FORBIDDEN $($args)*) };
+    (404 $($args:tt)*) => { $crate::raise!(NOT_FOUND $($args)*) };
+    (405 $($args:tt)*) => { $crate::raise!(METHOD_NOT_ALLOWED $($args)*) };
+    (406 $($args:tt)*) => { $crate::raise!(NOT_ACCEPTABLE $($args)*) };
+    (407 $($args:tt)*) => { $crate::raise!(PROXY_AUTHENTICATION_REQUIRED $($args)*) };
+    (408 $($args:tt)*) => { $crate::raise!(REQUEST_TIMEOUT $($args)*) };
+    (409 $($args:tt)*) => { $crate::raise!(CONFLICT $($args)*) };
+    (410 $($args:tt)*) => { $crate::raise!(GONE $($args)*) };
+    (411 $($args:tt)*) => { $crate::raise!(LENGTH_REQUIRED $($args)*) };
+    (412 $($args:tt)*) => { $crate::raise!(PRECONDITION_FAILED $($args)*) };
+    (413 $($args:tt)*) => { $crate::raise!(PAYLOAD_TOO_LARGE $($args)*) };
+    (414 $($args:tt)*) => { $crate::raise!(URI_TOO_LONG $($args)*) };
+    (415 $($args:tt)*) => { $crate::raise!(UNSUPPORTED_MEDIA_TYPE $($args)*) };
+    (416 $($args:tt)*) => { $crate::raise!(RANGE_NOT_SATISFIABLE $($args)*) };
+    (417 $($args:tt)*) => { $crate::raise!(EXPECTATION_FAILED $($args)*) };
+    (418 $($args:tt)*) => { $crate::raise!(IM_A_TEAPOT $($args)*) };
+    (421 $($args:tt)*) => { $crate::raise!(MISDIRECTED_REQUEST $($args)*) };
+    (422 $($args:tt)*) => { $crate::raise!(UNPROCESSABLE_ENTITY $($args)*) };
+    (423 $($args:tt)*) => { $crate::raise!(LOCKED $($args)*) };
+    (424 $($args:tt)*) => { $crate::raise!(FAILED_DEPENDENCY $($args)*) };
+    (426 $($args:tt)*) => { $crate::raise!(UPGRADE_REQUIRED $($args)*) };
+    (428 $($args:tt)*) => { $crate::raise!(PRECONDITION_REQUIRED $($args)*) };
+    (429 $($args:tt)*) => { $crate::raise!(TOO_MANY_REQUESTS $($args)*) };
+    (431 $($args:tt)*) => { $crate::raise!(REQUEST_HEADER_FIELDS_TOO_LARGE $($args)*) };
+    (451 $($args:tt)*) => { $crate::raise!(UNAVAILABLE_FOR_LEGAL_REASONS $($args)*) };
+    (500 $($args:tt)*) => { $crate::raise!(INTERNAL_SERVER_ERROR $($args)*) };
+    (501 $($args:tt)*) => { $crate::raise!(NOT_IMPLEMENTED $($args)*) };
+    (502 $($args:tt)*) => { $crate::raise!(BAD_GATEWAY $($args)*) };
+    (503 $($args:tt)*) => { $crate::raise!(SERVICE_UNAVAILABLE $($args)*) };
+    (504 $($args:tt)*) => { $crate::raise!(GATEWAY_TIMEOUT $($args)*) };
+    (505 $($args:tt)*) => { $crate::raise!(HTTP_VERSION_NOT_SUPPORTED $($args)*) };
+    (506 $($args:tt)*) => { $crate::raise!(VARIANT_ALSO_NEGOTIATES $($args)*) };
+    (507 $($args:tt)*) => { $crate::raise!(INSUFFICIENT_STORAGE $($args)*) };
+    (508 $($args:tt)*) => { $crate::raise!(LOOP_DETECTED $($args)*) };
+    (510 $($args:tt)*) => { $crate::raise!(NOT_EXTENDED $($args)*) };
+    (511 $($args:tt)*) => { $crate::raise!(NETWORK_AUTHENTICATION_REQUIRED $($args)*) };
+
     ($status:ident $($args:tt)*) => {
-        $crate::__via_impl_err!(@ctor $crate::error::StatusCode::$status $($args)*)
+        $crate::raise!(@ctor $crate::error::StatusCode::$status $($args)*)
     };
 
-    /*
-     * Define standard (or well-known) error status codes.
-     */
-    (400 $($args:tt)*) => { $crate::__via_impl_err!(BAD_REQUEST $($args)*) };
-    (401 $($args:tt)*) => { $crate::__via_impl_err!(UNAUTHORIZED $($args)*) };
-    (402 $($args:tt)*) => { $crate::__via_impl_err!(PAYMENT_REQUIRED $($args)*) };
-    (403 $($args:tt)*) => { $crate::__via_impl_err!(FORBIDDEN $($args)*) };
-    (404 $($args:tt)*) => { $crate::__via_impl_err!(NOT_FOUND $($args)*) };
-    (405 $($args:tt)*) => { $crate::__via_impl_err!(METHOD_NOT_ALLOWED $($args)*) };
-    (406 $($args:tt)*) => { $crate::__via_impl_err!(NOT_ACCEPTABLE $($args)*) };
-    (407 $($args:tt)*) => { $crate::__via_impl_err!(PROXY_AUTHENTICATION_REQUIRED $($args)*) };
-    (408 $($args:tt)*) => { $crate::__via_impl_err!(REQUEST_TIMEOUT $($args)*) };
-    (409 $($args:tt)*) => { $crate::__via_impl_err!(CONFLICT $($args)*) };
-    (410 $($args:tt)*) => { $crate::__via_impl_err!(GONE $($args)*) };
-    (411 $($args:tt)*) => { $crate::__via_impl_err!(LENGTH_REQUIRED $($args)*) };
-    (412 $($args:tt)*) => { $crate::__via_impl_err!(PRECONDITION_FAILED $($args)*) };
-    (413 $($args:tt)*) => { $crate::__via_impl_err!(PAYLOAD_TOO_LARGE $($args)*) };
-    (414 $($args:tt)*) => { $crate::__via_impl_err!(URI_TOO_LONG $($args)*) };
-    (415 $($args:tt)*) => { $crate::__via_impl_err!(UNSUPPORTED_MEDIA_TYPE $($args)*) };
-    (416 $($args:tt)*) => { $crate::__via_impl_err!(RANGE_NOT_SATISFIABLE $($args)*) };
-    (417 $($args:tt)*) => { $crate::__via_impl_err!(EXPECTATION_FAILED $($args)*) };
-    (418 $($args:tt)*) => { $crate::__via_impl_err!(IM_A_TEAPOT $($args)*) };
-    (421 $($args:tt)*) => { $crate::__via_impl_err!(MISDIRECTED_REQUEST $($args)*) };
-    (422 $($args:tt)*) => { $crate::__via_impl_err!(UNPROCESSABLE_ENTITY $($args)*) };
-    (423 $($args:tt)*) => { $crate::__via_impl_err!(LOCKED $($args)*) };
-    (424 $($args:tt)*) => { $crate::__via_impl_err!(FAILED_DEPENDENCY $($args)*) };
-    (426 $($args:tt)*) => { $crate::__via_impl_err!(UPGRADE_REQUIRED $($args)*) };
-    (428 $($args:tt)*) => { $crate::__via_impl_err!(PRECONDITION_REQUIRED $($args)*) };
-    (429 $($args:tt)*) => { $crate::__via_impl_err!(TOO_MANY_REQUESTS $($args)*) };
-    (431 $($args:tt)*) => { $crate::__via_impl_err!(REQUEST_HEADER_FIELDS_TOO_LARGE $($args)*) };
-    (451 $($args:tt)*) => { $crate::__via_impl_err!(UNAVAILABLE_FOR_LEGAL_REASONS $($args)*) };
-    (500 $($args:tt)*) => { $crate::__via_impl_err!(INTERNAL_SERVER_ERROR $($args)*) };
-    (501 $($args:tt)*) => { $crate::__via_impl_err!(NOT_IMPLEMENTED $($args)*) };
-    (502 $($args:tt)*) => { $crate::__via_impl_err!(BAD_GATEWAY $($args)*) };
-    (503 $($args:tt)*) => { $crate::__via_impl_err!(SERVICE_UNAVAILABLE $($args)*) };
-    (504 $($args:tt)*) => { $crate::__via_impl_err!(GATEWAY_TIMEOUT $($args)*) };
-    (505 $($args:tt)*) => { $crate::__via_impl_err!(HTTP_VERSION_NOT_SUPPORTED $($args)*) };
-    (506 $($args:tt)*) => { $crate::__via_impl_err!(VARIANT_ALSO_NEGOTIATES $($args)*) };
-    (507 $($args:tt)*) => { $crate::__via_impl_err!(INSUFFICIENT_STORAGE $($args)*) };
-    (508 $($args:tt)*) => { $crate::__via_impl_err!(LOOP_DETECTED $($args)*) };
-    (510 $($args:tt)*) => { $crate::__via_impl_err!(NOT_EXTENDED $($args)*) };
-    (511 $($args:tt)*) => { $crate::__via_impl_err!(NETWORK_AUTHENTICATION_REQUIRED $($args)*) };
-
-    /*
-     * Non-standard error status code support.
-     */
     ($code:literal $($args:tt)*) => {{
         const CODE: u16 = $code;
         const _: () = assert!(
@@ -164,6 +145,6 @@ macro_rules! __via_impl_err {
             unreachable!()
         };
 
-        $crate::__via_impl_err!(@ctor status $($args)*)
+        $crate::raise!(@ctor status $($args)*)
     }};
 }

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
 use crate::error::{BoxError, Error};
-use crate::{Payload, err};
+use crate::{Payload, raise};
 
 #[derive(Debug)]
 pub struct RequestBody(Either<Limited<Incoming>, BoxBody<Bytes, BoxError>>);
@@ -29,16 +29,18 @@ pub struct DataAndTrailers {
     trailers: Option<HeaderMap>,
 }
 
-fn already_read() -> Error {
-    err!(500, message = "The request body has already been read.")
+fn already_read<T>() -> Result<T, Error> {
+    raise!(500, message = "The request body has already been read.")
 }
 
-fn into_future_error(error: BoxError) -> Error {
+fn into_future_error<T>(error: BoxError) -> Result<T, Error> {
     if error.is::<LengthLimitError>() {
-        err!(413, boxed = error) // Payload Too Large
-    } else {
-        err!(400, boxed = error) // Bad Request
+        // Payload Too Large
+        raise!(413, boxed = error);
     }
+
+    // Bad Request
+    raise!(400, boxed = error);
 }
 
 impl IntoFuture {
@@ -59,11 +61,11 @@ impl Future for IntoFuture {
 
         loop {
             let Some(result) = ready!(body.as_mut().poll_frame(context)) else {
-                return Poll::Ready(payload.take().ok_or_else(already_read));
+                return Poll::Ready(payload.take().map_or_else(already_read, Ok));
             };
 
-            let frame = result.map_err(into_future_error)?;
-            let payload = payload.as_mut().ok_or_else(already_read)?;
+            let frame = result.or_else(into_future_error)?;
+            let payload = payload.as_mut().map_or_else(already_read, Ok)?;
 
             match frame.into_data() {
                 Ok(data) => payload.frames.push(data),

--- a/src/request/param/path_param.rs
+++ b/src/request/param/path_param.rs
@@ -1,9 +1,8 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
-use crate::error::Error;
 use crate::util::UriEncoding;
-use crate::{err, raise};
+use crate::{Error, raise};
 
 pub struct PathParam<'a, 'b> {
     encoding: UriEncoding,
@@ -45,7 +44,7 @@ impl<'a, 'b> PathParam<'a, 'b> {
     {
         self.into_result()?
             .parse()
-            .map_err(|error| err!(400, error))
+            .or_else(|error| raise!(400, error))
     }
 
     pub fn unwrap_or<U>(self, or: U) -> Cow<'a, str>

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -317,7 +317,7 @@ impl<State> RequestHead<State> {
             .get(key)
             .map(|value| value.to_str())
             .transpose()
-            .map_err(|error| crate::err!(400, error))
+            .or_else(|error| crate::raise!(400, error))
     }
 
     /// Returns reference to the cookies associated with the request.

--- a/src/util/uri_encoding.rs
+++ b/src/util/uri_encoding.rs
@@ -18,6 +18,6 @@ impl UriEncoding {
 
         percent_decode_str(input)
             .decode_utf8()
-            .map_err(|error| crate::err!(400, error))
+            .or_else(|error| crate::raise!(400, error))
     }
 }


### PR DESCRIPTION
Removes the `err!` macro in favor of using `raise!` exclusively. `.map_err` is really the only valid use-case for `err!` anyways.