### PR TITLE
chore(via-router): bump version to v2.0.0-gm.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
 smallvec = { version = "1", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-via-router = { path = "./via-router" }
+via-router = { version = "3.0.0-beta.30" }
 
 [dependencies.aws-lc-rs]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-gm"
+via = "2.0.0-gm.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
Bump via to version `v2.0.0-gm.1`.