### PR TITLE
fix(via): do not obfuscate AppService

### DIFF
--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -1,7 +1,5 @@
 use hyper::server::conn;
-use hyper::service::{Service, service_fn};
 use hyper_util::rt::{TokioIo, TokioTimer};
-use std::convert::Infallible;
 use std::error::Error;
 use std::mem;
 use std::process::ExitCode;
@@ -17,7 +15,6 @@ use hyper_util::rt::TokioExecutor;
 
 use super::io::IoWithPermit;
 use super::server::ServerConfig;
-use crate::Response;
 use crate::app::AppService;
 use crate::error::ServerError;
 
@@ -118,13 +115,6 @@ where
         // Spawn a task to serve the connection.
         connections.spawn(async move {
             let io = IoWithPermit::new(TokioIo::new(handshake.await?), permit);
-            let service = service_fn(|request| {
-                let future = service.call(request);
-                async {
-                    let response = future.await.unwrap_or_else(Response::from);
-                    Ok::<_, Infallible>(response.into())
-                }
-            });
 
             // Create a new HTTP/2 connection.
             #[cfg(feature = "http2")]


### PR DESCRIPTION
Favors a custom future type as opposed to obfuscating `AppService` by calling it from a service fn.

Unless you are running your application in Debug mode, it should be incredibly difficult to obtain the memory address of the future returned from `AppService::call`. The future type does not implement `Debug` and properly projects the inner `Pin<Box<Future>>` so it can be polled in order to get a response.

This change is neutral to the security of Via applications. However, it does somewhat reduce the attack surface area by eliminating ambiguity for the compiler.