### PR TITLE
chore(via-router): bump version to v3.0.0-beta.31

### DIFF
--- a/via-router/Cargo.toml
+++ b/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.30"
+version = "3.0.0-beta.31"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps via-router to v3.0.0-beta.31.

---

### Changelog

- #346
