### PR TITLE
chore(via): update via-router to v3.0.0-beta.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
 smallvec = { version = "1", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-via-router = { path = "./via-router" }
+via-router = { version = "3.0.0-beta.31" }
 
 [dependencies.aws-lc-rs]
 version = "1"


### PR DESCRIPTION
Updates the dependency on via-router to the latest release published on crates.io.