### PR TITLE
feat(via): configurable tls handshake timeout

### DIFF
--- a/src/error/server.rs
+++ b/src/error/server.rs
@@ -14,6 +14,9 @@ pub(crate) enum ServerError {
     // This variant is only used when a tls backend is enabled.
     #[allow(dead_code)]
     Tls(BoxError),
+
+    #[allow(dead_code)]
+    HandshakeTimeout,
 }
 
 impl Display for ServerError {
@@ -23,6 +26,12 @@ impl Display for ServerError {
             Self::Join(error) => Display::fmt(error, f),
             Self::Http(error) => Display::fmt(error, f),
             Self::Tls(error) => Display::fmt(error, f),
+            Self::HandshakeTimeout => {
+                writeln!(
+                    f,
+                    "tls negotiation did not finish within the configured timeout",
+                )
+            }
         }
     }
 }
@@ -34,6 +43,7 @@ impl std::error::Error for ServerError {
             Self::Join(error) => error.source(),
             Self::Http(error) => error.source(),
             Self::Tls(error) => error.source(),
+            _ => None,
         }
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -21,6 +21,9 @@ pub(super) struct ServerConfig {
     pub(super) max_connections: usize,
     pub(super) max_request_size: usize,
     pub(super) shutdown_timeout: Duration,
+
+    #[cfg(any(feature = "native-tls", feature = "rustls"))]
+    pub(super) tls_handshake_timeout: Option<Duration>,
 }
 
 impl<App> Server<App>
@@ -74,6 +77,22 @@ where
         Self {
             config: ServerConfig {
                 shutdown_timeout,
+                ..self.config
+            },
+            ..self
+        }
+    }
+
+    /// The amount of time in seconds that an individual connection task will
+    /// wait for the TLS handshake to complete before closing the connection.
+    ///
+    /// **Default:** `10s`
+    ///
+    #[cfg(any(feature = "native-tls", feature = "rustls"))]
+    pub fn tls_handshake_timeout(self, tls_handshake_timeout: Option<Duration>) -> Self {
+        Self {
+            config: ServerConfig {
+                tls_handshake_timeout,
                 ..self.config
             },
             ..self
@@ -178,6 +197,9 @@ impl Default for ServerConfig {
             max_connections: 1000,
             max_request_size: 104_857_600, // 100 MB
             shutdown_timeout: Duration::from_secs(30),
+
+            #[cfg(any(feature = "native-tls", feature = "rustls"))]
+            tls_handshake_timeout: Some(Duration::from_secs(10)),
         }
     }
 }


### PR DESCRIPTION
This change improves the security and resilience of servers built with Via by eliminating a denial-of-service vector in the TLS negotiation logic. Previously, an attacker could exploit the TLS handshake process to drive the connection semaphore to capacity, preventing legitimate connections from being accepted.

By ensuring that TLS negotiation cannot indefinitely or disproportionately consume semaphore permits, this change prevents handshake-level resource exhaustion and preserves availability under adversarial or degraded network conditions.