### PR TITLE
chore(via): bump version to 2.0.0-gm.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-gm.5"
+version = "2.0.0-gm.6"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-gm.5"
+via = "2.0.0-gm.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
Bumps Via to `v2.0.0-gm.6`.

---

### Changelog

- #352
- #353 
- #354