### PR TITLE
fix(via): top-level tls acceptor imports

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -8,6 +8,12 @@ use super::tls::TcpAcceptor;
 use crate::app::{AppService, Via};
 use crate::error::Error;
 
+#[cfg(feature = "native-tls")]
+use super::tls::NativeTlsAcceptor;
+
+#[cfg(feature = "rustls")]
+use super::tls::RustlsAcceptor;
+
 /// Serve an app over HTTP.
 ///
 pub struct Server<App> {
@@ -162,7 +168,7 @@ where
     where
         A: ToSocketAddrs,
     {
-        let acceptor = super::tls::NativeTlsAcceptor::new(identity);
+        let acceptor = NativeTlsAcceptor::new(identity);
         let service = AppService::new(Arc::new(self.app), self.config.max_request_size);
 
         async {
@@ -180,7 +186,7 @@ where
     where
         A: ToSocketAddrs,
     {
-        let acceptor = super::tls::RustlsAcceptor::new(rustls_config);
+        let acceptor = RustlsAcceptor::new(rustls_config);
         let service = AppService::new(Arc::new(self.app), self.config.max_request_size);
 
         async {


### PR DESCRIPTION
Fixes a bug in the latest release that prevents applications that use a TLS backend from compiling.