### PR TITLE
chore(via): upgrade tws to v0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ optional = true
 default-features = false
 
 [dependencies.tokio-websockets]
-version = "0.12"
-features = ["aws_lc_rs", "server"]
+version = "0.13"
+features = ["server"]
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Upgrades tokio-websockets to the latest stable version.