### PR TITLE
fix(via): build and test ws module in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --features tokio-tungstenite
 
       - name: test router
         uses: actions-rs/cargo@v1
@@ -61,7 +62,7 @@ jobs:
           rustc --version
 
       - name: clippy
-        run: cargo clippy --tests --examples -- -D warnings
+        run: cargo clippy --features tokio-tungstenite --tests --examples -- -D warnings
 
       - name: fmt
         run: cargo fmt --all -- --check

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -20,17 +20,17 @@ pub use upgrade::Ws;
 /// use via::ws::{self, Channel, Message};
 /// use via::{Error, Server};
 ///
-/// async fn echo(mut channel: Channel, _: ws::Request<()>) -> ws::Result {
+/// async fn echo(mut channel: Channel, _: ws::Request) -> ws::Result {
 ///     while let Some(message) = channel.recv().await {
-///         match message {
-///             forward @ (Message::Binary(_) | Message::Text(_)) => {
-///                 channel.send(forward).await?;
-///             }
-///             ignore => {
-///                 if cfg!(debug_assertions) {
-///                     println!("{:?}", ignore);
-///                 }
-///             }
+///         if message.is_close() {
+///             println!("info: close requested by client");
+///             break;
+///         }
+///
+///         if message.is_binary() || message.is_text() {
+///             channel.send(message).await?;
+///         } else if cfg!(debug_assertions) {
+///             println!("warn: ignoring message {:?}", message);
 ///         }
 ///     }
 ///

--- a/src/ws/request.rs
+++ b/src/ws/request.rs
@@ -4,7 +4,7 @@ use crate::app::Shared;
 use crate::request::Envelope;
 
 #[derive(Debug)]
-pub struct Request<App> {
+pub struct Request<App = ()> {
     envelope: Arc<Envelope>,
     app: Shared<App>,
 }


### PR DESCRIPTION
A non-functional change that builds the ws module in GitHub actions.

Previously, the ws module was tested as a by product of the chat example being built as a part of CI. As we move closer to an official 2.0 release, many of the more complicated examples in the examples directory will be moving to discrete repositories.

In order to maintain the quality of releases that we intend to maintain moving forward, it's imperative that we build the ws module with at least one of the ws backend enabled as a part of our SDLC.  