### PR TITLE
feat(via): follow safety critical coding guidelines in accept

### DIFF
--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -123,8 +123,8 @@ async fn drain_connections(immediate: bool, mut connections: JoinSet<Result<(), 
     while let Some(result) = connections.join_next().await {
         match result {
             Ok(Ok(_)) => {}
-            Err(ref error) => log!("error(connection): {}", error),
-            Ok(Err(ref error)) => log!("error(service): {}", error),
+            Err(error) => log!("error(connection): {}", error),
+            Ok(Err(error)) => log!("error(service): {}", error),
         }
 
         if !immediate {


### PR DESCRIPTION
Implements the current safety critical [guidelines](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines) as defined by the [Safety Critical Rust Consortium](https://github.com/rustfoundation/safety-critical-rust-consortium). Namely, not using a macro for something that could be an `#[inline(always)] fn` or in this case, an expression.