### PR TITLE
chore(via-router): v3.0.0-beta.33 release

### DIFF
--- a/via-router/Cargo.toml
+++ b/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.32"
+version = "3.0.0-beta.33"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Updates the via-router version to v3.0.0-beta.33 in preparation for release.

---

### Changelog

- #383
