### PR TITLE
chore(via): v2.0.0-gm.10 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-gm.9"
+version = "2.0.0-gm.10"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-gm.9"
+via = "2.0.0-gm.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
Updates the via-router version to v2.0.0-gm.10 in preparation for release.

---

### Changelog

- #380
- #379
- #378
- #377
- #376
- #375 
- #374
- #373 
- #372
- #371
