### PR TITLE
fix(via): ws uses ring for sha1 accept keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ http2 = ["hyper/http2"]
 native-tls = ["dep:native-tls", "dep:tokio-native-tls"]
 rustls = ["dep:rustls", "dep:tokio-rustls"]
 
-tokio-tungstenite = ["dep:base64", "dep:futures-util", "dep:sha1", "dep:tungstenite", "dep:tokio-tungstenite"]
-tokio-websockets = ["dep:base64", "dep:futures-util", "dep:sha1", "dep:tokio-websockets"]
+tokio-tungstenite = ["dep:base64", "dep:futures-util", "dep:ring", "dep:tungstenite", "dep:tokio-tungstenite"]
+tokio-websockets = ["dep:base64", "dep:futures-util", "dep:ring", "dep:tokio-websockets"]
 
 [dependencies]
 aws-lc-rs = { version = "1", optional = true }
@@ -43,7 +43,6 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
-sha1 = { version = "0.10", optional = true }
 smallvec = { version = "1", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tokio-util = { version = "0.7", default-features = false }
@@ -101,7 +100,6 @@ uuid = { version = "1", features = ["v4", "serde"] }
 [[example]]
 name = "echo"
 path = "./examples/echo.rs"
-required-features = ["ring", "tokio-tungstenite"]
 
 [[example]]
 name = "files"

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,8 +23,16 @@ The classic echo server example with a ws relay for GET requests.
 
 ### Running the Example
 
+**Tungstenite**
+
 ```sh
-cargo run --features="ring tokio-tungstenite" --example echo
+cargo run --example echo --features="tokio-tungstenite"
+```
+
+**tokio-websockets**
+
+```sh
+cargo run --example echo --features="tokio-websockets"
 ```
 
 ---
@@ -130,3 +138,16 @@ cargo run --example files --features="file"
 
 Visit http://localhost:8080/ in your browser to see a nostalgic web page with
 an image of space on the about page.
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,12 +1,17 @@
 use std::process::ExitCode;
-use via::ws::{self, Channel};
 use via::{Error, Finalize, Next, Request, Response, Server};
 
 async fn echo(request: Request, _: Next) -> via::Result {
     request.finalize(Response::build())
 }
 
-async fn relay(mut channel: Channel, _: ws::Request) -> ws::Result {
+#[cfg(not(any(feature = "tokio-tungstenite", feature = "tokio-websockets")))]
+async fn relay(request: Request, next: Next) -> via::Result {
+    next.call(request).await
+}
+
+#[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
+async fn relay(mut channel: via::ws::Channel, _: via::ws::Request) -> via::ws::Result {
     while let Some(message) = channel.recv().await {
         if message.is_close() {
             eprintln!("info: close requested by client");
@@ -27,7 +32,10 @@ async fn relay(mut channel: Channel, _: ws::Request) -> ws::Result {
 async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
-    app.route("/echo").to(via::get(via::ws(relay)).post(echo));
+    #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
+    let relay = via::ws(relay);
+
+    app.route("/echo").to(via::post(echo).get(relay));
 
     Server::new(app).listen(("127.0.0.1", 8080)).await
 }

--- a/src/ws/upgrade.rs
+++ b/src/ws/upgrade.rs
@@ -3,7 +3,7 @@ use futures_util::{SinkExt, StreamExt};
 use http::{Method, StatusCode, header};
 use hyper::upgrade::{OnUpgrade, Upgraded};
 use hyper_util::rt::TokioIo;
-use sha1::{Digest, Sha1};
+use ring::digest::{Context as Hasher, SHA1_FOR_LEGACY_USE_ONLY};
 use std::ops::ControlFlow::{Break, Continue};
 use std::sync::Arc;
 
@@ -33,12 +33,12 @@ struct WsConfig {
 }
 
 fn gen_accept_key(key: &[u8]) -> String {
-    let mut hasher = Sha1::new();
+    let mut hasher = Hasher::new(&SHA1_FOR_LEGACY_USE_ONLY);
 
     hasher.update(key);
     hasher.update(WS_ACCEPT_GUID);
 
-    base64.encode(hasher.finalize())
+    base64.encode(hasher.finish())
 }
 
 #[cfg(feature = "tokio-tungstenite")]


### PR DESCRIPTION
Use `ring` rather than the `sha1` crate for websocket upgrades.

We already offer ring as an option for a crypto backend when using rustls as a TLS backend. [They think like us](https://github.com/briansmith/ring/blob/HEAD/SIDE-CHANNELS.md). It makes sense.