### PR TITLE
fix(via): precondition at the top of Service::call

### DIFF
--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -45,6 +45,13 @@ impl<App> Service<http::Request<Incoming>> for AppService<App> {
     type Response = http::Response<ResponseBody>;
 
     fn call(&self, request: http::Request<Incoming>) -> Self::Future {
+        // Immediately respond with 414 if the path length exceeds the maximum.
+        if request.uri().path().len() > MAX_URI_PATH_LEN {
+            return FutureResponse(Box::pin(async {
+                raise!(414, message = MAX_PATH_LEN_EXCEEDED);
+            }));
+        }
+
         // The middleware stack.
         let mut deque = VecDeque::with_capacity(18);
 
@@ -61,12 +68,6 @@ impl<App> Service<http::Request<Incoming>> for AppService<App> {
 
         // Get a mutable ref to params and a shared ref to the uri path.
         let (params, path) = request.envelope_mut().params_mut_with_path();
-
-        if path.len() > MAX_URI_PATH_LEN {
-            return FutureResponse(Box::pin(async {
-                raise!(414, message = MAX_PATH_LEN_EXCEEDED);
-            }));
-        }
 
         // Populate the middleware stack with the resolved routes.
         for (route, param) in self.app.router.traverse(path) {


### PR DESCRIPTION
Moves the precondition that performs a bounds check on the request URI path to the top of `Service::call`. Reducing allocator pressure in the event that someone is attempting a DoS. 

This is a fundamental that I try to follow anytime I'm writing safety critical code. This fell by the wayside by prioritizing the fewest amount of instructions by reusing the ref we take to path right before routing the request. However, preventing allocator pressure based DoS is definitely more important.