### PR TITLE
fix(via): select connection version based on alpn version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,15 @@ homepage = "https://github.com/zacharygolba/via"
 repository = "https://github.com/zacharygolba/via"
 
 [features]
-default = ["http1"]
+default = []
 
 aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 ring = ["dep:ring", "tokio-rustls/ring"]
 
 file = ["dep:httpdate", "tokio/fs"]
 
-http1 = ["hyper/http1"]
-http2 = ["hyper/http2"]
-
-native-tls = ["dep:native-tls", "dep:tokio-native-tls"]
-rustls = ["dep:rustls", "dep:tokio-rustls"]
+native-tls = ["dep:native-tls", "dep:tokio-native-tls", "hyper/http2"]
+rustls = ["dep:rustls", "dep:tokio-rustls", "hyper/http2"]
 
 tokio-tungstenite = ["dep:base64", "dep:futures-util", "dep:ring", "dep:tungstenite", "dep:tokio-tungstenite"]
 tokio-websockets = ["dep:base64", "dep:futures-util", "dep:ring", "dep:tokio-websockets"]
@@ -38,7 +35,7 @@ http = "1"
 http-body = "1"
 http-body-util = "0.1"
 httpdate = { version = "1", optional = true }
-hyper = { version = "1", features = ["server"] }
+hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"]  }

--- a/examples/tls/rustls.rs
+++ b/examples/tls/rustls.rs
@@ -50,7 +50,7 @@ mod tls {
             .with_single_cert(certs, key)
             .expect("tls config is invalid or missing");
 
-        config.alpn_protocols = vec![b"h2".to_vec()];
+        config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
         config
     }

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -10,7 +10,7 @@ use tokio::task::{JoinSet, coop};
 use tokio::{signal, time};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
-use super::{Acceptor, IoWithPermit, ServerConfig};
+use super::{IoWithPermit, ServerConfig, tls};
 use crate::app::AppService;
 use crate::error::ServerError;
 
@@ -34,7 +34,7 @@ pub(super) async fn accept<App, TlsAcceptor>(
 where
     App: Send + Sync + 'static,
     ServerError: From<TlsAcceptor::Error>,
-    TlsAcceptor: Acceptor,
+    TlsAcceptor: tls::Acceptor,
     TlsAcceptor::Io: Send + Unpin + 'static,
 {
     #[cfg(not(any(feature = "native-tls", feature = "rustls")))]
@@ -84,21 +84,33 @@ where
             continue;
         };
 
-        #[cfg(any(feature = "native-tls", feature = "rustls"))]
-        let handshake = acceptor.accept(io);
-
         let service = service.clone();
         let shutdown = shutdown.clone();
 
         // Spawn a task to serve the connection.
-        connections.spawn(async move {
-            #[cfg(any(feature = "native-tls", feature = "rustls"))]
-            let io = match config.tls_handshake_timeout {
-                Some(duration) => time::timeout(duration, handshake).await??,
-                None => handshake.await?,
-            };
+        #[cfg(any(feature = "native-tls", feature = "rustls"))]
+        connections.spawn({
+            let handshake = time::timeout(
+                config.tls_handshake_timeout.unwrap_or_default(),
+                acceptor.accept(io),
+            );
 
-            serve_connection(IoWithPermit::new(io, permit), service, shutdown).await
+            async move {
+                let (io, alpn) = handshake.await??;
+                let io = IoWithPermit::new(io, permit);
+
+                if alpn == tls::Alpn::H2 {
+                    serve_h2_connection(io, service, shutdown).await
+                } else {
+                    serve_connection(io, service, shutdown).await
+                }
+            }
+        });
+
+        #[cfg(not(any(feature = "native-tls", feature = "rustls")))]
+        connections.spawn(async move {
+            let io = IoWithPermit::new(io, permit);
+            serve_connection(io, service, shutdown).await
         });
 
         if connections.len() >= 1024 {
@@ -135,38 +147,6 @@ async fn drain_connections(immediate: bool, mut connections: JoinSet<Result<(), 
     }
 }
 
-#[cfg(feature = "http2")]
-async fn serve_connection<App, Io>(
-    io: IoWithPermit<Io>,
-    service: AppService<App>,
-    shutdown: InitializationToken,
-) -> Result<(), ServerError>
-where
-    App: Send + Sync + 'static,
-    Io: AsyncRead + AsyncWrite + Send + Unpin + 'static,
-{
-    let connection = conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new())
-        .timer(TokioTimer::new())
-        .serve_connection(io, service);
-
-    tokio::pin!(connection);
-
-    tokio::select! {
-        // Keep tail latency low when the server is at capacity.
-        biased;
-
-        // The connection future is ready.
-        result = &mut connection => Ok(result?),
-
-        // A graceful shutdown signal was sent to the process.
-        _ = shutdown.requested() => {
-            connection.as_mut().graceful_shutdown();
-            Ok((&mut connection).await?)
-        }
-    }
-}
-
-#[cfg(all(feature = "http1", not(feature = "http2")))]
 async fn serve_connection<App, Io>(
     io: IoWithPermit<Io>,
     service: AppService<App>,
@@ -182,7 +162,36 @@ where
         .with_upgrades();
 
     tokio::pin!(connection);
+    tokio::select! {
+        // Keep tail latency low when the server is at capacity.
+        biased;
 
+        // The connection future is ready.
+        result = &mut connection => Ok(result?),
+
+        // A graceful shutdown signal was sent to the process.
+        _ = shutdown.requested() => {
+            connection.as_mut().graceful_shutdown();
+            Ok((&mut connection).await?)
+        }
+    }
+}
+
+#[cfg(any(feature = "native-tls", feature = "rustls"))]
+async fn serve_h2_connection<App, Io>(
+    io: IoWithPermit<Io>,
+    service: AppService<App>,
+    shutdown: InitializationToken,
+) -> Result<(), ServerError>
+where
+    App: Send + Sync + 'static,
+    Io: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    let connection = conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new())
+        .timer(TokioTimer::new())
+        .serve_connection(io, service);
+
+    tokio::pin!(connection);
     tokio::select! {
         // Keep tail latency low when the server is at capacity.
         biased;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,7 +14,7 @@ use crate::app::{AppService, Via};
 use crate::error::Error;
 use accept::accept;
 use io::IoWithPermit;
-use tls::{Acceptor, TcpAcceptor};
+use tls::TcpAcceptor;
 
 #[cfg(feature = "native-tls")]
 use tls::NativeTlsAcceptor;

--- a/src/server/tls.rs
+++ b/src/server/tls.rs
@@ -1,3 +1,4 @@
+use http::Version;
 use std::error::Error;
 use std::io;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -9,6 +10,9 @@ pub use native::NativeTlsAcceptor;
 #[cfg(feature = "rustls")]
 pub use rustls::RustlsAcceptor;
 
+#[derive(Eq, PartialEq)]
+pub struct Alpn(Version);
+
 pub struct TcpAcceptor;
 
 pub trait Acceptor {
@@ -19,7 +23,7 @@ pub trait Acceptor {
     fn accept(
         &self,
         io: TcpStream,
-    ) -> impl Future<Output = Result<Self::Io, Self::Error>> + Send + 'static;
+    ) -> impl Future<Output = Result<(Self::Io, Alpn), Self::Error>> + Send + 'static;
 }
 
 impl Acceptor for TcpAcceptor {
@@ -30,9 +34,15 @@ impl Acceptor for TcpAcceptor {
     fn accept(
         &self,
         _: TcpStream,
-    ) -> impl Future<Output = Result<Self::Io, Self::Error>> + Send + 'static {
+    ) -> impl Future<Output = Result<(Self::Io, Alpn), Self::Error>> + Send + 'static {
         async { unreachable!() }
     }
+}
+
+#[allow(dead_code)]
+impl Alpn {
+    pub const H2: Self = Self(Version::HTTP_2);
+    pub const HTTP_11: Self = Self(Version::HTTP_11);
 }
 
 #[cfg(feature = "native-tls")]
@@ -42,7 +52,7 @@ mod native {
     use tokio::net::TcpStream;
     use tokio_native_tls::{TlsAcceptor, TlsStream};
 
-    use super::Acceptor;
+    use super::{Acceptor, Alpn};
 
     pub struct NativeTlsAcceptor(Arc<TlsAcceptor>);
 
@@ -64,9 +74,19 @@ mod native {
         fn accept(
             &self,
             io: TcpStream,
-        ) -> impl Future<Output = Result<Self::Io, Self::Error>> + Send + 'static {
+        ) -> impl Future<Output = Result<(Self::Io, Alpn), Self::Error>> + Send + 'static {
             let acceptor = Arc::clone(&self.0);
-            async move { acceptor.accept(io).await }
+
+            async move {
+                let io = acceptor.accept(io).await?;
+                let stream = io.get_ref();
+                let alpn = stream
+                    .negotiated_alpn()?
+                    .and_then(|negotiated| (negotiated == b"h2").then_some(Alpn::H2))
+                    .unwrap_or(Alpn::HTTP_11);
+
+                Ok((io, alpn))
+            }
         }
     }
 }
@@ -78,7 +98,7 @@ mod rustls {
     use tokio::net::TcpStream;
     use tokio_rustls::server::{TlsAcceptor, TlsStream};
 
-    use super::Acceptor;
+    use super::{Acceptor, Alpn};
 
     pub struct RustlsAcceptor(TlsAcceptor);
 
@@ -95,8 +115,19 @@ mod rustls {
         fn accept(
             &self,
             io: TcpStream,
-        ) -> impl Future<Output = Result<Self::Io, Self::Error>> + Send + 'static {
-            self.0.accept(io)
+        ) -> impl Future<Output = Result<(Self::Io, Alpn), Self::Error>> + Send + 'static {
+            let future = self.0.accept(io);
+
+            async move {
+                let io = future.await?;
+                let (_, conn) = io.get_ref();
+                let alpn = conn
+                    .alpn_protocol()
+                    .and_then(|negotiated| (negotiated == b"h2").then_some(Alpn::H2))
+                    .unwrap_or(Alpn::HTTP_11);
+
+                Ok((io, alpn))
+            }
         }
     }
 }


### PR DESCRIPTION
Avoids HTTP version based feature flags in favor of automatically selected the http version based on alpn negotiation.

This PR introduces a feature that is _essential_ for the seamless use of Via in production.

---

_Note:_ tokio-native-tls does not seem to handle alpn negotation directly.

I'm personally unaware of how one configures alpn protocols for the various native TLS implementations on each platform.

However, if any work has to be done on the tokio-native-tls side or if possible—configuring a system-wide preferred alpn protocol order for the native platform implementations should work with our `NativeTlsAcceptor` with no additional changes to our code. 