### PR TITLE
fix(via): use super::Response in response::file

### DIFF
--- a/src/response/file.rs
+++ b/src/response/file.rs
@@ -14,8 +14,7 @@ use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncRead, ReadBuf};
 use tokio::{task, time};
 
-use super::builder::{Finalize, ResponseBuilder};
-use super::response::Response;
+use super::{Finalize, Response, ResponseBuilder};
 use crate::error::{BoxError, Error};
 
 /// The base amount of time that the server will wait before


### PR DESCRIPTION
Fixes a bug that prevents the files example from working the docs from build.

Side note: the file server API could use a little love. I'd put my life on a locked down version of the rest of the API though. Docker or Podman. :peace_symbol:
