### PR TITLE
chore(via): v2.0.0-gm.15 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-gm.14"
+version = "2.0.0-gm.15"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-gm.14"
+via = "2.0.0-gm.15"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
Updates the version of Via to v2.0.0-gm.15 in preparation for release.

---

### Changelog

- #408
- #407
- #406
- #405 
