### PR TITLE
refactor(via): collection and member are discrete macros

### DIFF
--- a/via/src/rest.rs
+++ b/via/src/rest.rs
@@ -1,28 +1,22 @@
 #[macro_export]
-macro_rules! rest {
-    ($mod:path) => {
-        (
-            $crate::rest!($mod as collection),
-            $crate::rest!($mod as member),
-        )
-    };
-    ($mod:path as collection) => {{
+macro_rules! collection {
+    ($mod:path) => {{
         use $mod::{create, index};
         $crate::post(create).get(index)
     }};
-    ($mod:path as member) => {{
+}
+
+#[macro_export]
+macro_rules! member {
+    ($mod:path) => {{
         use $mod::{destroy, show, update};
         $crate::delete(destroy).patch(update).get(show)
     }};
-    ($mod:path as $other:ident) => {{
-        compile_error!(concat!(
-            "incorrect rest! modifier \"",
-            stringify!($other),
-            "\"",
-        ));
-    }};
+}
 
-    ($mod:ident, $param:literal) => {{
+#[macro_export]
+macro_rules! rest {
+    ($mod:path, $param:literal) => {{
         assert!(
             $param.starts_with(|start| start == ':' || start == '*'),
             "parameter names must start with either : or *."
@@ -36,7 +30,7 @@ macro_rules! rest {
         )
     }};
 
-    ($mod:ident, $param:literal, $name:literal) => {{
+    ($mod:path, $param:literal, $name:literal) => {{
         assert!(
             $param.starts_with(|start| start == ':' || start == '*'),
             "parameter names must start with either : or *."
@@ -50,8 +44,8 @@ macro_rules! rest {
         )
     }};
 
-    (#[resource] $mod:ident, $collection:expr, $member:expr) => {
-        $crate::router::ResourceBuilder::collection($collection, $crate::rest!($mod as collection))
-            .member($member, $crate::rest!($mod as member))
+    (#[resource] $mod:path, $collection:expr, $member:expr) => {
+        $crate::router::ResourceBuilder::collection($collection, $crate::collection!($mod))
+            .member($member, $crate::member!($mod))
     };
 }


### PR DESCRIPTION
We're slated for a code freeze as we approach a stable 2.0 release. This is the second to the last breaking change that we'll make ahead of a code freeze. During the code freeze, documentation, examples, and additive features (populating the guard module) is what you can expect.

We are at the point where following semver is more effective than rapid iteration. If we have to make a breaking change after the stable release, we'll bump the major version.

**Breaking Change:**

The `rest!` macro syntax feels a bit odd with the `as collection` and `as member` modifiers. An easy solution is splitting concerns into separate macros, that's what this PR does.