### PR TITLE
refactor(via): ws middleware is passed to via::get

### DIFF
--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -1,4 +1,4 @@
-use http::{HeaderValue, Method, StatusCode, header};
+use http::{HeaderValue, StatusCode, header};
 use hyper::upgrade::OnUpgrade;
 use std::future::Future;
 use std::sync::Arc;
@@ -131,14 +131,13 @@ where
 {
     fn call(&self, mut request: crate::Request<App>, next: Next<App>) -> BoxFuture {
         // Confirm that the request is for a websocket upgrade.
-        if request.method() != Method::GET
-            || !request
-                .headers()
-                .get(header::CONNECTION)
-                .zip(request.headers().get(header::UPGRADE))
-                .is_some_and(|(connection, upgrade)| {
-                    has_token(connection, "upgrade") && has_token(upgrade, "websocket")
-                })
+        if !request
+            .headers()
+            .get(header::CONNECTION)
+            .zip(request.headers().get(header::UPGRADE))
+            .is_some_and(|(connection, upgrade)| {
+                has_token(connection, "upgrade") && has_token(upgrade, "websocket")
+            })
         {
             return next.call(request);
         }


### PR DESCRIPTION
**Breaking Change:**

Via's router DSL provides an API that plays very well with function composition. In order to encourage our users to build combinators for the router DSL, similar to `nom`—we must set the right example.

This change moves the http method equality check outside of the ws upgrade flow to the http method-based dispatch functions defined in the router module.

In addition to setting the right example for our users, we also don't want middleware dispatch to be meaningfully different than any other HTTP request. Passing `via::ws` to `via::get` solves this problem by not providing a signal for an adversary to distinguish a web socket upgrade from any other request.

## Example

```rust
app.route("chat").to(via::get(via::ws(routes::chat)));
```