### PR TITLE
fix(via): error response uses a json array for errors

### DIFF
--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -62,6 +62,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
+smallvec = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tokio-websockets = { version = "0.13", features = ["ring", "server"], optional = true }
 via-router = { version = "3.0.0-beta.34" }

--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -7,7 +7,10 @@ mod result;
 mod server;
 
 use http::{StatusCode, header};
+use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
+use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io::{self, Error as IoError};
 
@@ -31,6 +34,8 @@ pub struct Error {
     source: ErrorSource,
 }
 
+struct ErrorList<'a>(SmallVec<[Cow<'a, str>; 1]>);
+
 #[derive(Debug)]
 enum ErrorSource {
     AllowMethod(Box<MethodNotAllowed>),
@@ -44,13 +49,6 @@ enum ErrorSourceRef<'a> {
     Message(&'a str),
     Other(&'a (dyn std::error::Error + 'static)),
     Json(&'a serde_json::Error),
-}
-
-#[derive(Serialize)]
-#[serde(untagged)]
-enum ErrorList<'a> {
-    Original(&'a str),
-    Chain(Vec<String>),
 }
 
 #[derive(Serialize)]
@@ -204,23 +202,31 @@ impl Error {
         }
     }
 
-    fn repr_json(&self) -> Errors<'_> {
-        if let ErrorSourceRef::Message(message) = self.as_source() {
-            Errors::new(self.status, message)
-        } else {
-            let mut errors = Vec::with_capacity(12);
-            let mut source = self.source();
-
-            while let Some(error) = source {
-                errors.push(error.to_string());
-                source = error.source();
-            }
-
-            // Reverse the order of the error messages to match the call stack.
-            errors.reverse();
-
-            Errors::chain(self.status, errors)
+    fn as_message_or_source(&self) -> Result<&str, Option<&(dyn std::error::Error + 'static)>> {
+        match &self.source {
+            ErrorSource::Message(message) => Ok(message.as_ref()),
+            ErrorSource::AllowMethod(error) => Err(Some(error)),
+            ErrorSource::Other(error) => Err(Some(&**error)),
+            ErrorSource::Json(error) => Err(Some(error)),
         }
+    }
+
+    fn repr_json(&self) -> Errors<'_> {
+        let mut errors = Errors::new(self.status);
+
+        match self.as_message_or_source() {
+            Ok(message) => {
+                errors.push(Cow::Borrowed(message));
+            }
+            Err(mut source) => {
+                while let Some(error) = source {
+                    errors.push(error.to_string().into());
+                    source = error.source();
+                }
+            }
+        }
+
+        errors
     }
 }
 
@@ -281,17 +287,30 @@ impl Serialize for Error {
 }
 
 impl<'a> Errors<'a> {
-    fn new(status: StatusCode, message: &'a str) -> Self {
+    fn new(status: StatusCode) -> Self {
         Self {
             status,
-            errors: ErrorList::Original(message),
+            errors: ErrorList(SmallVec::new()),
         }
     }
 
-    fn chain(status: StatusCode, chain: Vec<String>) -> Self {
-        Self {
-            status,
-            errors: ErrorList::Chain(chain),
-        }
+    fn push(&mut self, message: Cow<'a, str>) {
+        self.errors.0.push(message);
+    }
+}
+
+impl Serialize for ErrorList<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_seq(Some(self.0.len()))?;
+
+        self.0
+            .iter()
+            .rev()
+            .try_for_each(|message| state.serialize_element(message.as_ref()))?;
+
+        state.end()
     }
 }

--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -223,6 +223,8 @@ impl Error {
                     errors.push(error.to_string().into());
                     source = error.source();
                 }
+
+                errors.reverse();
             }
         }
 
@@ -297,6 +299,10 @@ impl<'a> Errors<'a> {
     fn push(&mut self, message: Cow<'a, str>) {
         self.errors.0.push(message);
     }
+
+    fn reverse(&mut self) {
+        self.errors.0.reverse();
+    }
 }
 
 impl Serialize for ErrorList<'_> {
@@ -306,10 +312,9 @@ impl Serialize for ErrorList<'_> {
     {
         let mut state = serializer.serialize_seq(Some(self.0.len()))?;
 
-        self.0
-            .iter()
-            .rev()
-            .try_for_each(|message| state.serialize_element(message.as_ref()))?;
+        for message in &self.0 {
+            state.serialize_element(message.as_ref())?;
+        }
 
         state.end()
     }

--- a/via/src/error/rescue.rs
+++ b/via/src/error/rescue.rs
@@ -117,7 +117,7 @@ impl Display for Sanitizer<'_> {
 }
 
 impl Finalize for Sanitizer<'_> {
-    fn finalize(self, builder: ResponseBuilder) -> Result<Response, Error> {
+    fn finalize(mut self, builder: ResponseBuilder) -> Result<Response, Error> {
         let mut builder = builder.status(self.status());
 
         if let ErrorSourceRef::AllowMethod(error) = self.error.as_source()
@@ -127,11 +127,11 @@ impl Finalize for Sanitizer<'_> {
         }
 
         if self.json {
-            let json = self.message.as_deref().map_or_else(
+            let json = self.message.take().map_or_else(
                 || self.error.repr_json(),
                 |message| {
                     let mut errors = Errors::new(self.status());
-                    errors.push(Cow::Borrowed(message));
+                    errors.push(message);
                     errors
                 },
             );

--- a/via/src/error/rescue.rs
+++ b/via/src/error/rescue.rs
@@ -129,7 +129,11 @@ impl Finalize for Sanitizer<'_> {
         if self.json {
             let json = self.message.as_deref().map_or_else(
                 || self.error.repr_json(),
-                |message| Errors::new(self.status(), message),
+                |message| {
+                    let mut errors = Errors::new(self.status());
+                    errors.push(Cow::Borrowed(message));
+                    errors
+                },
             );
 
             builder.json(&json)


### PR DESCRIPTION
Fixes a regression where errors in error responses were conditionally serialized as a JSON array.