### PR TITLE
fix(via): ws task returns unit type + internal log macro improvements

### DIFF
--- a/via/src/ws/mod.rs
+++ b/via/src/ws/mod.rs
@@ -7,6 +7,19 @@ compile_error!("either \"aws-lc-rs\" or \"ring\" must be enabled to use the ws m
 #[cfg(all(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
 compile_error!("features \"tokio-tungstenite\" and \"tokio-websockets\" are mutually exclusive.");
 
+macro_rules! log {
+    ($level:tt($indent:literal), $fmt:literal $($arg:tt)*) => {
+        if cfg!(debug_assertions) {
+            eprintln!(
+                "{}{}(via::ws): {}",
+                " ".repeat($indent),
+                stringify!($level),
+                format_args!($fmt $($arg)*)
+            );
+        }
+    };
+}
+
 mod channel;
 mod error;
 mod io;

--- a/via/src/ws/mod.rs
+++ b/via/src/ws/mod.rs
@@ -9,14 +9,14 @@ compile_error!("features \"tokio-tungstenite\" and \"tokio-websockets\" are mutu
 
 macro_rules! log {
     ($level:tt($indent:literal), $fmt:literal $($arg:tt)*) => {
-        if cfg!(debug_assertions) {
-            eprintln!(
-                "{}{}(via::ws): {}",
-                " ".repeat($indent),
-                stringify!($level),
-                format_args!($fmt $($arg)*)
-            );
-        }
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "{:indent$}{}(via::ws): {}",
+            "",
+            stringify!($level),
+            format_args!($fmt $($arg)*),
+            indent = $indent
+        );
     };
 }
 

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -89,21 +89,6 @@ impl Drop for Facade {
     }
 }
 
-macro_rules! log {
-    ($level:tt($indent:literal), $fmt:literal $($arg:tt)*) => {
-        log!(
-            concat!("{}", stringify!($level),"(via::ws): ", $fmt),
-            " ".repeat($indent)
-            $($arg)*
-        )
-    };
-    ($($args:tt)+) => {
-        if cfg!(debug_assertions) {
-            eprintln!($($args)*);
-        }
-    };
-}
-
 impl Future for Facade {
     type Output = super::Result;
 
@@ -167,7 +152,7 @@ impl Future for Facade {
 
                     if let IoState::Send(message) = mem::replace(state, IoState::Flush) {
                         sink.as_mut().start_send(message).map_err(rescue)?;
-                        log!(info(2), "write successful. transitiion to flush.");
+                        log!(info(2), "write successful. transition to flush.");
                     } else {
                         // We are in an invalid state. This can be interpreted
                         // as a signal that the risk of re-entrance is elevated

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -171,8 +171,17 @@ where
             let request = super::Request::new(request);
 
             tokio::spawn(async move {
-                let stream = handshake(&listener.config, upgrade).await?;
-                RunTask::new(listener, request, stream).await
+                let task = match handshake(&listener.config, upgrade).await {
+                    Ok(stream) => RunTask::new(listener, request, stream),
+                    Err(error) => {
+                        log!(error(0), "{}", &error);
+                        return;
+                    }
+                };
+
+                if let Err(error) = task.await {
+                    log!(error(0), "{}", &error);
+                }
             });
 
             Response::build()


### PR DESCRIPTION
This change updates the ws reactor task to use the result returned from the task future. Also, the log macro has been simplified and updated to ensure it does not exist in release builds.  