### PR TITLE
feat(via): once! is a util for cold path warnings in debug builds

### DIFF
--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -626,16 +626,11 @@ impl Body for RequestBody {
 
             hint.set_lower(self.body.size_hint().lower());
 
-            if cfg!(debug_assertions) {
-                use std::sync::Once;
-
-                static ONCE: Once = Once::new();
-
-                ONCE.call_once(|| {
-                    print!("warn: a lossy size hint must be used for RequestBody. ");
-                    println!("usize::MAX exceeds u64::MAX on this platform.");
-                });
-            }
+            #[cfg(debug_assertions)]
+            crate::util::once!(|| {
+                print!("warn(via): a lossy size hint must be used for RequestBody. ");
+                println!("usize::MAX exceeds u64::MAX on this platform.");
+            });
 
             return hint;
         };

--- a/via/src/util/mod.rs
+++ b/via/src/util/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(debug_assertions)]
+mod once;
 mod uri_encoding;
+
+#[cfg(debug_assertions)]
+pub(crate) use once::once;
 
 pub use uri_encoding::UriEncoding;

--- a/via/src/util/once.rs
+++ b/via/src/util/once.rs
@@ -1,0 +1,12 @@
+/// Call the provided closure once.
+macro_rules! once {
+    ($call:expr) => {
+        static __1: std::sync::Once = std::sync::Once::new();
+        __1.call_once(|| {
+            print!("warn: a lossy size hint must be used for RequestBody. ");
+            println!("usize::MAX exceeds u64::MAX on this platform.");
+        });
+    };
+}
+
+pub(crate) use once;


### PR DESCRIPTION
Abstracts the one time debug message in the implementation of `RequestBody::size_hint` into a macro that can be reused to provide helpful warning messages to our users with zero impact on release builds.