### PR TITLE
fix(via): overflow check in impl Body for RequestBody does not use ? 

### DIFF
--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -604,13 +604,12 @@ impl Body for RequestBody {
         };
 
         if let Some(data) = frame.data_ref() {
-            self.remaining = self
-                .remaining
-                .checked_sub(data.remaining())
-                .ok_or_else(|| {
-                    self.remaining = 0;
-                    Error::payload_too_large()
-                })?;
+            let Some(remaining) = self.remaining.checked_sub(data.remaining()) else {
+                self.remaining = 0;
+                return Poll::Ready(Some(Err(Error::payload_too_large())));
+            };
+
+            self.remaining = remaining;
         }
 
         Poll::Ready(Some(Ok(frame)))


### PR DESCRIPTION
This PR builds on top of #517 by making the control flow of the post poll bounds check on `self.remaining` for `Coalesce` easier to read.