### PR TITLE
feat(via): timeout helpers for reading a request body

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -23,7 +23,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
     let (body, _app) = request.into_future();
 
     // Aggregate the frames of the request body and then deserialize a Document<Hello>.
-    let hello: Document<Hello> = body.await?.json()?;
+    let hello: Document<Hello> = body.timeout_after_secs(5).await?.json()?;
 
     // Send a JSON response with our greeting message.
     Response::build().json(&Document {

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -10,6 +10,7 @@ use std::ptr;
 use std::rc::Rc;
 use std::sync::atomic::{Ordering, compiler_fence};
 use std::task::{Context, Poll, ready};
+use std::time::Duration;
 
 use crate::{Error, err};
 
@@ -499,6 +500,39 @@ impl Payload for Bytes {
     }
 }
 
+macro_rules! impl_timeout_after {
+    ($ty:ident) => {
+        impl $ty {
+            /// Respond with a `408` Request Timeout error if the future is not
+            /// ready within the specified duration.
+            pub async fn timeout_after(self, duration: Duration) -> Result<Aggregate, Error> {
+                let Ok(result) = tokio::time::timeout(duration, self).await else {
+                    crate::deny!(408, "request timeout.");
+                };
+
+                result
+            }
+
+            /// Respond with a `408` Request Timeout error if the future is not
+            /// ready within the specified timeout in seconds.
+            pub fn timeout_after_secs(
+                self,
+                seconds: u64,
+            ) -> impl Future<Output = Result<Aggregate, Error>> {
+                self.timeout_after(Duration::from_secs(seconds))
+            }
+        }
+    };
+}
+
+fn already_read() -> Error {
+    err!(500, "a request body can only be read once.")
+}
+
+fn unknown_frame_type() -> Error {
+    err!(400, "unknown frame type encountered in request.")
+}
+
 impl Coalesce {
     pub fn with_trailers(self) -> WithTrailers {
         WithTrailers {
@@ -508,18 +542,12 @@ impl Coalesce {
     }
 }
 
+impl_timeout_after!(Coalesce);
+
 impl Coalesce {
     pub(super) fn new(body: RequestBody) -> Self {
         Self { body }
     }
-}
-
-fn already_read() -> Error {
-    err!(500, "a request body can only be read once.")
-}
-
-fn unknown_frame_type() -> Error {
-    err!(400, "unknown frame type encountered in request.")
 }
 
 impl Future for Coalesce {
@@ -536,6 +564,8 @@ impl Future for Coalesce {
         Poll::Ready(self.body.finish(None))
     }
 }
+
+impl_timeout_after!(WithTrailers);
 
 impl Future for WithTrailers {
     type Output = Result<Aggregate, Error>;


### PR DESCRIPTION
Provides an easy way for enforcing a timeout when reading a request body.

We want to make the process of adding a timeout to reading a request body as seamless as possible so DoS vectors that involve resource retention (in this case, heap memory + fd) become, for the most—inexcusable.

This is implemented internally as a macro rather than a trait because applying a timeout is something that can be done to any Future and we only have two types that we want to implement these helper functions for. Sealing the trait is excessive and opening it is confusing because it creates an alternative syntax to the timeout macro that really only makes sense for this use-case.
