### PR TITLE
feat(via): header_read_timeout is configurable for http1

### DIFF
--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -171,6 +171,7 @@ where
         .max_buf_size(service.config().max_buf_size())
         .pipeline_flush(false)
         .preserve_header_case(false)
+        .header_read_timeout(Some(service.config().http1_header_read_timeout()))
         .timer(TokioTimer::new())
         .title_case_headers(false)
         .serve_connection(io, service)

--- a/via/src/server/mod.rs
+++ b/via/src/server/mod.rs
@@ -119,8 +119,11 @@ where
     ///
     /// **Default:** `10s`
     /// **Max:** `30s`
-    pub fn http1_header_read_timeout(mut self, http1_header_read_timeout: Duration) -> Self {
-        self.config.http1_header_read_timeout = http1_header_read_timeout;
+    pub fn http1_header_read_timeout(mut self, duration: Duration) -> Self {
+        self.config.http1_header_read_timeout = (duration <= Duration::from_secs(30))
+            .then_some(duration)
+            .expect("\"http1_header_read_timeout\" exceeds maximum value of 30 seconds.");
+
         self
     }
 

--- a/via/src/server/mod.rs
+++ b/via/src/server/mod.rs
@@ -36,6 +36,7 @@ pub(crate) struct ServerConfig {
     max_connections: usize,
     max_request_size: usize,
     shutdown_timeout: Duration,
+    http1_header_read_timeout: Duration,
 
     #[cfg(any(feature = "native-tls", feature = "rustls-23"))]
     tls_handshake_timeout: Duration,
@@ -104,12 +105,22 @@ where
         self
     }
 
-    /// Set the amount of time in seconds that the server will wait for inflight
+    /// Sets the amount of time that the server will wait for inflight
     /// connections to complete before shutting down.
     ///
     /// **Default:** `10s`
     pub fn shutdown_timeout(mut self, shutdown_timeout: Duration) -> Self {
         self.config.shutdown_timeout = shutdown_timeout;
+        self
+    }
+
+    /// If a client does not transmit the entire header within this time, the
+    /// connection is closed.
+    ///
+    /// **Default:** `10s`
+    /// **Max:** `30s`
+    pub fn http1_header_read_timeout(mut self, http1_header_read_timeout: Duration) -> Self {
+        self.config.http1_header_read_timeout = http1_header_read_timeout;
         self
     }
 
@@ -265,6 +276,10 @@ impl ServerConfig {
     pub fn shutdown_timeout(&self) -> Duration {
         self.shutdown_timeout
     }
+
+    pub fn http1_header_read_timeout(&self) -> Duration {
+        self.http1_header_read_timeout.min(Duration::from_secs(30))
+    }
 }
 
 #[cfg(any(feature = "native-tls", feature = "rustls-23"))]
@@ -290,6 +305,7 @@ impl Default for ServerConfig {
             max_connections: 1000,
             max_request_size: 104_857_600, // 100 MB
             shutdown_timeout: Duration::from_secs(10),
+            http1_header_read_timeout: Duration::from_secs(10),
 
             #[cfg(any(feature = "native-tls", feature = "rustls-23"))]
             http2_max_concurrent_streams: Some(64),

--- a/via/src/server/mod.rs
+++ b/via/src/server/mod.rs
@@ -114,8 +114,8 @@ where
         self
     }
 
-    /// If a client does not transmit the entire header within this time, the
-    /// connection is closed.
+    /// If a client does not transmit the entire request head within this time,
+    /// the connection is closed.
     ///
     /// **Default:** `10s`
     /// **Max:** `30s`


### PR DESCRIPTION
Introduces a configurable header_read_timeout for http1 connections. This change introduces also introduces a new default value of 10s rather than 30s to match the shutdown_timeout.

For added assurance, the header_read_timeout cannot be disabled for http1 connections and the duration of the timeout is capped to 30s.