### PR TITLE
refactor(via): guard::AndThen ~> guard::Bind

### DIFF
--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -18,7 +18,7 @@ pub type Content<T, U> = (
 );
 
 /// Apply a guard's predicate to an individual middleware.
-pub struct AndThen<T, U> {
+pub struct Bind<T, U> {
     middleware: U,
     guard: Guard<T>,
 }
@@ -112,7 +112,7 @@ pub fn content<T, U>(accepts: T, provides: U) -> Guard<Content<T, U>> {
     ))
 }
 
-impl<T, U, App> Middleware<App> for AndThen<T, U>
+impl<T, U, App> Middleware<App> for Bind<T, U>
 where
     T: Predicate<Request<App>> + Send + Sync,
     for<'a> T::Error<'a>: Into<Error>,
@@ -145,8 +145,8 @@ where
 
 impl<T> Guard<T> {
     /// Apply the guard's predicate to `middleware`.
-    pub fn and_then<U>(self, middleware: U) -> AndThen<T, U> {
-        AndThen {
+    pub fn bind<U>(self, middleware: U) -> Bind<T, U> {
+        Bind {
             middleware,
             guard: self,
         }


### PR DESCRIPTION
This PR renames `guard::AndThen` to `guard::Bind`.

`AndThen` implies boolean logic that can chain multiple middlewares or guards together. The name `AndThen` also implies a symmetrical `OrElse` adapter that would be logically asymmetrical by design. The closest opposite of `AndThen` in the guard module is `Filter`.

---

- `guard::Bind` applies a predicate to an individual middleware rather than a subtree of the router. Can be thought of like the `?` operator as it stops execution if the predicate is not met.

```rust
// Collapse the auth guard of a websocket handler into a single middleware.
//
// This saves you an atomic operation and BoxFuture for GET requests to /chat
// and prevents non-authenticated users from initiating a websocket upgrade.
app.route("/chat").to(guard::bind(
    // Attach a contextual error to a boolean predicate.
    guard::map_err(|_| Unauthorized, Session::is_authenticated),
    via::get(ws(chat)),
));
```

---

- `guard::Filter` applies a predicate to an individual middleware and only calls it if the predicate matches. If the predicate doesn't match, execution of the route's middleware stack continues.

```rust
// For the average REST API, 80% of requests can skip verifying that the user
// associated with the request's identity exists and avoid an additional layer
// of pointer indirection required when you decorate the response returned by
// descendant middleware.
app.middleware(guard::filter(
    guard::or((guard::method::is_mutation(), Session::needs_refresh)),
    refresh_session,
));
```

---

<details>
  <summary>Module scope from the examples:</summary> 

```rust
use via::{Error, Next, Request, guard, ws};

#[derive(Clone)]
struct Identity([u8; 16]);

// Use a custom struct as a guard error to defer converting to via::Error until
// the guard is ready to send an error response.
struct Unauthorized;

trait Session {
    fn is_authenticated(&self) -> bool { todo!() }
    fn needs_refresh(&self) -> bool { todo!() }
    fn session(&self) -> Option<&Identity>;
}

async fn chat(mut channel: ws::Channel, request: ws::Request) -> ws::Result {
    use via::ws::ResultExt;

    let user_id = request
        .session()
        .map_or(Err(Unauthorized), Identity::user_id)
        .or_disconnect()?;

    while let Some(_) = channel.recv().await {
        todo!()
    }

    Ok(())
}

async fn refresh_session(_: Request, _: Next) -> via::Result {
    todo!()
}

impl From<Unauthorized> for Error {
    fn from(_: Unauthorized) -> Self {
        via::err!(401, "unauthorized.")
    }
}

impl Session for Request {
    fn session(&self) -> Option<&Identity> {
        self.extensions().get()
    }
}

impl Session for ws::Request {
    fn session(&self) -> Option<&Identity> {
        self.envelope().extensions().get()
    }
}

impl Identity {
    pub fn needs_refresh(&self) -> bool { todo!() }
    pub fn refresh_at(&self) -> Result<i64, Unauthorized> { todo!() }
    pub fn user_id(&self) -> Result<NonZeroU64, Unauthorized> { todo!() }
}
```

</details>
