### PR TITLE
feat(via): non-capturing closures impl Predicate

### DIFF
--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -205,3 +205,15 @@ where
         Ok(())
     }
 }
+
+impl<F, Input> Predicate<Input> for F
+where
+    Input: ?Sized,
+    for<'a> F: Fn(&Input) -> bool + Copy + 'a,
+{
+    type Error<'a> = ();
+
+    fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
+        if (self)(input) { Ok(()) } else { Err(()) }
+    }
+}


### PR DESCRIPTION
Implements `Predicate` for closures that return a `bool` and do not capture state from their environment. Predicates (for the most part) are "atoms". If there is complex branching logic that you are putting in closure or has various failure modes, it's better to implement `Predicate` for a unit struct. This keeps the router DSL clean, and enables testing the predicate in isolation to prevent regressions.