### PR TITLE
refactor(via): guard::Guard is guard::FlatMap<T, Continue>

### DIFF
--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -9,7 +9,7 @@ pub use predicate::*;
 use std::fmt::Debug;
 
 use crate::request::Request;
-use crate::{BoxFuture, Error, Middleware, Next};
+use crate::{BoxFuture, Continue, Error, Middleware, Next};
 
 /// Content negotation as validation.
 pub type Content<T, U> = (
@@ -50,11 +50,28 @@ pub struct FlatMap<T, U> {
     middleware: U,
 }
 
-/// Stop processing the request and respond if the provided predicate fails.
+/// Call `middleware` if `predicate` matches the request.
+pub fn filter<T, U>(predicate: T, middleware: U) -> Filter<T, U> {
+    Filter {
+        predicate,
+        middleware,
+    }
+}
+
+/// Confirm that the request matches `predicate` before calling `middleware`.
 ///
-/// This is useful for lightweight, synchronous validations that do not require
-/// async work—such as authorization checks based on headers, request metadata,
-/// or other inexpensive predicates.
+/// Unlike [`guard`], the provided predicate only applies to `middleware`.
+pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
+    FlatMap {
+        predicate,
+        middleware,
+    }
+}
+
+/// Deny the request if it does not match `predicate`.
+///
+/// The `guard` fn is preferred when you want every request to a subtree of
+/// your app to match `predicate`.
 ///
 /// # Example
 ///
@@ -76,34 +93,8 @@ pub struct FlatMap<T, U> {
 ///     // Define the /api/users resource.
 /// });
 /// ```
-pub struct Guard<T> {
-    predicate: T,
-}
-
-/// Call `middleware` if `predicate` matches the request.
-pub fn filter<T, U>(predicate: T, middleware: U) -> Filter<T, U> {
-    Filter {
-        predicate,
-        middleware,
-    }
-}
-
-/// Confirm that the request matches `predicate` before calling `middleware`.
-///
-/// Unlike [`guard`], the provided predicate only applies to `middleware`.
-pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
-    FlatMap {
-        predicate,
-        middleware,
-    }
-}
-
-/// Deny the request if it does not match `predicate`.
-///
-/// Guard is preferred when you want every request to a subtree of your app to
-/// match `predicate`.
-pub fn guard<T>(predicate: T) -> Guard<T> {
-    Guard { predicate }
+pub fn guard<T>(predicate: T) -> FlatMap<T, Continue> {
+    flat_map(predicate, Continue)
 }
 
 /// Require that the header associated with `key` matches `predicate`.
@@ -122,7 +113,7 @@ where
 ///
 /// The first argument is what the client is allowed to send. The second
 /// argument is how the server will reply.
-pub fn content<T, U>(accepts: T, provides: U) -> Guard<Content<T, U>> {
+pub fn content<T, U>(accepts: T, provides: U) -> FlatMap<Content<T, U>, Continue> {
     guard((
         header::accept(provides),
         when(
@@ -159,22 +150,6 @@ where
             self.middleware.call(request, next)
         } else {
             next.call(request)
-        }
-    }
-}
-
-impl<T, App> Middleware<App> for Guard<T>
-where
-    T: Predicate<Request<App>> + Send + Sync,
-    for<'a> T::Error<'a>: Into<Error>,
-{
-    fn call(&self, request: Request<App>, next: Next<App>) -> BoxFuture {
-        match self.predicate.cmp(&request) {
-            Ok(_) => next.call(request),
-            Err(error) => {
-                let error = error.into();
-                Box::pin(async { Err(error) })
-            }
         }
     }
 }


### PR DESCRIPTION
Refactors the `guard::guard` fn to use `FlatMap` with `Continue`. 