### PR TITLE
refactor(via): ws upgrade flow is as clean as possible

### DIFF
--- a/via/src/ws/error.rs
+++ b/via/src/ws/error.rs
@@ -68,8 +68,8 @@ impl Display for UpgradeError {
     }
 }
 
-impl<'a> From<DenyHeader<'a>> for UpgradeError {
-    fn from(error: DenyHeader<'a>) -> Self {
+impl From<DenyHeader<'_>> for UpgradeError {
+    fn from(error: DenyHeader<'_>) -> Self {
         match error.name().as_str() {
             "sec-websocket-version" => UpgradeError::SecWebsocketVersion,
             "connection" => UpgradeError::UpgradeRequired,

--- a/via/src/ws/request.rs
+++ b/via/src/ws/request.rs
@@ -1,3 +1,4 @@
+use hyper::upgrade::OnUpgrade;
 use std::sync::Arc;
 
 use crate::app::Shared;
@@ -5,6 +6,7 @@ use crate::request::Envelope;
 
 #[derive(Debug)]
 pub struct Request<App = ()> {
+    pub(super) on_upgrade: Option<OnUpgrade>,
     envelope: Arc<Envelope>,
     app: Shared<App>,
 }
@@ -25,9 +27,10 @@ impl<App> Request<App> {
 
 impl<App> Request<App> {
     pub(super) fn new(request: crate::Request<App>) -> Self {
-        let (envelope, _, app) = request.into_parts();
+        let (mut envelope, _, app) = request.into_parts();
 
         Self {
+            on_upgrade: envelope.extensions_mut().remove(),
             envelope: Arc::new(envelope),
             app,
         }
@@ -37,6 +40,7 @@ impl<App> Request<App> {
 impl<App> Clone for Request<App> {
     fn clone(&self) -> Self {
         Self {
+            on_upgrade: None,
             envelope: Arc::clone(&self.envelope),
             app: self.app.clone(),
         }

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -243,6 +243,9 @@ where
                 Poll::Ready(Err(error))
             }
             Poll::Ready(Err(ControlFlow::Continue(error))) => {
+                #[cfg(not(debug_assertions))]
+                let _ = error;
+
                 log!(warn(2), "{}", &error);
 
                 this.reconnect();

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -1,29 +1,34 @@
 use http::StatusCode;
 use http::header::{self as h, HeaderMap};
-use hyper::upgrade::OnUpgrade;
 use std::future::Future;
 use std::sync::Arc;
 
 #[cfg(feature = "tokio-tungstenite")]
-use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::{
+    WebSocketStream,
+    tungstenite::protocol::{Role, WebSocketConfig},
+};
 
 #[cfg(feature = "tokio-websockets")]
 use tokio_websockets::WebSocketStream;
 
-use super::Channel;
 use super::io::UpgradedIo;
 use super::run::RunTask;
 use super::util::{Base64EncodedDigest, sha1};
-use crate::guard::header::{CaseSensitive, Contains, Header};
-use crate::guard::{Predicate, header};
+use super::{Channel, Request};
+use crate::guard::header::{CaseSensitive, Contains, DenyHeader, Header};
+use crate::guard::{self, MapErr, Predicate, header};
 use crate::ws::error::UpgradeError;
-use crate::{BoxFuture, Error, Middleware, Next, Request, Response, ResultExt, deny};
+use crate::{BoxFuture, Error, Middleware, Next, Response, ResultExt};
 
 const DEFAULT_FRAME_SIZE: usize = 16384; // 16KB
 
 pub struct Ws<T> {
     listener: Arc<Listener<T>>,
-    guard: (Header<CaseSensitive>, Header<Contains>, Header<Contains>),
+    guard: MapErr<
+        fn(DenyHeader<'_>) -> UpgradeError,
+        (Header<CaseSensitive>, Header<Contains>, Header<Contains>),
+    >,
 }
 
 pub(super) struct Listener<T> {
@@ -31,65 +36,73 @@ pub(super) struct Listener<T> {
     config: WsConfig,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 struct WsConfig {
     buffer_size: usize,
     max_frame_size: Option<usize>,
     max_message_size: Option<usize>,
 }
 
-#[cfg(feature = "tokio-tungstenite")]
-async fn handshake(
-    config: &WsConfig,
-    upgrade: OnUpgrade,
-) -> Result<WebSocketStream<UpgradedIo>, Error> {
-    use tungstenite::protocol::{Role, WebSocketConfig};
-
-    let max_message_size = config.max_message_size;
-    let mut config = WebSocketConfig::default()
-        .accept_unmasked_frames(false)
-        .read_buffer_size(config.buffer_size)
-        .max_frame_size(config.max_frame_size)
-        .max_message_size(max_message_size);
-
-    if let Some(capacity) = max_message_size.and_then(|limit| limit.checked_mul(2)) {
-        config = config.write_buffer_size(capacity);
-    }
-
-    let stream = WebSocketStream::from_raw_socket(
-        UpgradedIo::new(upgrade.await?),
-        Role::Server,
-        Some(config),
-    )
-    .await;
-
-    Ok(stream)
-}
-
-#[cfg(all(feature = "tokio-websockets", not(feature = "tokio-tungstenite")))]
-async fn handshake(
-    config: &WsConfig,
-    upgrade: OnUpgrade,
-) -> Result<WebSocketStream<UpgradedIo>, Error> {
-    use tokio_websockets::server::Builder;
-    use tokio_websockets::{Config, Limits};
-
-    let limits = Limits::default().max_payload_len(config.max_message_size);
-    let config = Config::default()
-        .frame_size(config.max_frame_size.unwrap_or(DEFAULT_FRAME_SIZE))
-        .flush_threshold(DEFAULT_FRAME_SIZE);
-
-    Ok(Builder::new()
-        .config(config)
-        .limits(limits)
-        .serve(UpgradedIo::new(upgrade.await?)))
-}
-
 #[inline(always)]
 fn configure<T>(listener: &mut Arc<Listener<T>>) -> &mut WsConfig {
     Arc::get_mut(listener)
         .map(|listener| &mut listener.config)
-        .expect("cannot be configure ws while the app is running.")
+        .expect("cannot configure ws while the app is running.")
+}
+
+#[cfg(feature = "tokio-tungstenite")]
+async fn open<App>(
+    request: &mut Request<App>,
+    config: &WsConfig,
+) -> Result<WebSocketStream<UpgradedIo>, Error> {
+    let on_upgrade = request.on_upgrade.take().ok_or(UpgradeError::Other)?;
+    let upgraded = UpgradedIo::new(on_upgrade.await?);
+    let config = WebSocketConfig::default()
+        .accept_unmasked_frames(false)
+        .read_buffer_size(config.buffer_size)
+        .write_buffer_size(config.buffer_size)
+        .max_frame_size(config.max_frame_size)
+        .max_message_size(config.max_message_size);
+
+    Ok(WebSocketStream::from_raw_socket(upgraded, Role::Server, Some(config)).await)
+}
+
+#[cfg(all(feature = "tokio-websockets", not(feature = "tokio-tungstenite")))]
+async fn open<App>(
+    request: &mut Request<App>,
+    config: &WsConfig,
+) -> Result<WebSocketStream<UpgradedIo>, Error> {
+    use tokio_websockets::{Config, Limits, server::Builder};
+
+    let on_upgrade = request.on_upgrade.take().ok_or(UpgradeError::Other)?;
+    let upgraded = UpgradedIo::new(on_upgrade.await?);
+    let limits = Limits::default().max_payload_len(config.max_message_size);
+    let config = Config::default()
+        .frame_size(config.max_frame_size.unwrap_or(DEFAULT_FRAME_SIZE))
+        .flush_threshold(config.buffer_size);
+
+    Ok(Builder::new().config(config).limits(limits).serve(upgraded))
+}
+
+async fn reactor<T, App, Await>(mut request: Request<App>, listener: Arc<Listener<T>>)
+where
+    T: Fn(Channel, Request<App>) -> Await + Send,
+    Await: Future<Output = super::Result> + Send + 'static,
+{
+    let err = match open(&mut request, &listener.config).await {
+        Err(error) => Some(error),
+        Ok(stream) => {
+            let task = RunTask::new(listener, request, stream);
+            task.await.err()
+        }
+    };
+
+    if let Some(error) = err.as_ref() {
+        #[cfg(not(debug_assertions))]
+        let _ = error;
+
+        log!(error(0), "{}", error);
+    }
 }
 
 impl<T> Ws<T> {
@@ -97,12 +110,19 @@ impl<T> Ws<T> {
         Self {
             listener: Arc::new(Listener {
                 handle: listener,
-                config: WsConfig::default(),
+                config: WsConfig {
+                    buffer_size: DEFAULT_FRAME_SIZE,
+                    max_frame_size: Some(DEFAULT_FRAME_SIZE),
+                    max_message_size: Some(DEFAULT_FRAME_SIZE),
+                },
             }),
-            guard: (
-                header(h::SEC_WEBSOCKET_VERSION, header::case_sensitive(b"13")),
-                header(h::CONNECTION, header::contains(header::tag(b"upgrade"))),
-                header(h::UPGRADE, header::contains(header::tag(b"websocket"))),
+            guard: guard::map_err(
+                |error| error.into(),
+                (
+                    header(h::SEC_WEBSOCKET_VERSION, header::case_sensitive(b"13")),
+                    header(h::CONNECTION, header::contains(header::tag(b"upgrade"))),
+                    header(h::UPGRADE, header::contains(header::tag(b"websocket"))),
+                ),
             ),
         }
     }
@@ -138,68 +158,39 @@ impl<T> Ws<T> {
 }
 
 impl<T> Ws<T> {
-    fn verify(&self, headers: &HeaderMap) -> Result<Base64EncodedDigest, UpgradeError> {
-        self.guard.cmp(headers)?;
-
-        let value = headers
-            .get(h::SEC_WEBSOCKET_KEY)
-            .ok_or(UpgradeError::SecWebsocketKey)?;
-
-        sha1(value.as_bytes())
+    #[inline]
+    fn validate(&self, headers: &HeaderMap) -> Result<Base64EncodedDigest, UpgradeError> {
+        self.guard
+            .cmp(headers)
+            .and_then(|_| match headers.get(h::SEC_WEBSOCKET_KEY) {
+                Some(key) => sha1(key.as_bytes()),
+                None => Err(UpgradeError::SecWebsocketKey),
+            })
     }
 }
 
 impl<T, App, Await> Middleware<App> for Ws<T>
 where
-    T: Fn(Channel, super::Request<App>) -> Await + Send + Sync + 'static,
+    T: Fn(Channel, Request<App>) -> Await + Send + Sync + 'static,
     App: Send + Sync + 'static,
     Await: Future<Output = super::Result> + Send + 'static,
 {
-    fn call(&self, mut request: Request<App>, _: Next<App>) -> BoxFuture {
+    fn call(&self, request: crate::Request<App>, _: Next<App>) -> BoxFuture {
         let listener = Arc::clone(&self.listener);
+        let is_valid = self.validate(request.headers());
 
-        let Some(upgrade) = request.extensions_mut().remove() else {
-            return Box::pin(async { deny!(500, UpgradeError::Other) });
-        };
-
-        let accept = match self.verify(request.headers()).or_bad_request() {
-            Ok(digest) => digest,
-            Err(error) => return Box::pin(async { Err(error) }),
-        };
-
-        Box::pin(async move {
-            let request = super::Request::new(request);
-
-            tokio::spawn(async move {
-                let task = match handshake(&listener.config, upgrade).await {
-                    Ok(stream) => RunTask::new(listener, request, stream),
-                    Err(error) => {
-                        log!(error(0), "{}", &error);
-                        return;
-                    }
-                };
-
-                if let Err(error) = task.await {
-                    log!(error(0), "{}", &error);
-                }
-            });
-
-            Response::build()
+        Box::pin(async {
+            let accept = is_valid.or_bad_request()?;
+            let result = Response::build()
                 .status(StatusCode::SWITCHING_PROTOCOLS)
                 .header(h::CONNECTION, "upgrade")
                 .header(h::SEC_WEBSOCKET_ACCEPT, accept.as_str())
                 .header(h::UPGRADE, "websocket")
-                .finish()
-        })
-    }
-}
+                .finish();
 
-impl Default for WsConfig {
-    fn default() -> Self {
-        Self {
-            buffer_size: DEFAULT_FRAME_SIZE,
-            max_frame_size: Some(DEFAULT_FRAME_SIZE),
-            max_message_size: Some(DEFAULT_FRAME_SIZE),
-        }
+            tokio::spawn(reactor(Request::new(request), listener));
+
+            result
+        })
     }
 }

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -55,7 +55,7 @@ async fn open<App>(
     request: &mut Request<App>,
     config: &WsConfig,
 ) -> Result<WebSocketStream<UpgradedIo>, Error> {
-    let on_upgrade = request.on_upgrade.take().ok_or(UpgradeError::Other)?;
+    let on_upgrade = request.on_upgrade.take().expect("already upgraded.");
     let upgraded = UpgradedIo::new(on_upgrade.await?);
     let config = WebSocketConfig::default()
         .accept_unmasked_frames(false)
@@ -74,7 +74,7 @@ async fn open<App>(
 ) -> Result<WebSocketStream<UpgradedIo>, Error> {
     use tokio_websockets::{Config, Limits, server::Builder};
 
-    let on_upgrade = request.on_upgrade.take().ok_or(UpgradeError::Other)?;
+    let on_upgrade = request.on_upgrade.take().expect("already upgraded.");
     let upgraded = UpgradedIo::new(on_upgrade.await?);
     let limits = Limits::default().max_payload_len(config.max_message_size);
     let config = Config::default()

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -17,8 +17,8 @@ use super::io::UpgradedIo;
 use super::run::RunTask;
 use super::util::{Base64EncodedDigest, sha1};
 use super::{Channel, Request};
-use crate::guard::header::{CaseSensitive, Contains, DenyHeader, Header};
-use crate::guard::{self, MapErr, Predicate, header};
+use crate::guard::header::{CaseSensitive, Contains, Header};
+use crate::guard::{Predicate, header};
 use crate::ws::error::UpgradeError;
 use crate::{BoxFuture, Error, Middleware, Next, Response, ResultExt};
 
@@ -26,10 +26,7 @@ const DEFAULT_FRAME_SIZE: usize = 16384; // 16KB
 
 pub struct Ws<T> {
     listener: Arc<Listener<T>>,
-    guard: MapErr<
-        fn(DenyHeader<'_>) -> UpgradeError,
-        (Header<CaseSensitive>, Header<Contains>, Header<Contains>),
-    >,
+    guard: (Header<CaseSensitive>, Header<Contains>, Header<Contains>),
 }
 
 pub(super) struct Listener<T> {
@@ -117,13 +114,10 @@ impl<T> Ws<T> {
                     max_message_size: Some(DEFAULT_FRAME_SIZE),
                 },
             }),
-            guard: guard::map_err(
-                |error| error.into(),
-                (
-                    header(h::SEC_WEBSOCKET_VERSION, header::case_sensitive(b"13")),
-                    header(h::CONNECTION, header::contains(header::tag(b"upgrade"))),
-                    header(h::UPGRADE, header::contains(header::tag(b"websocket"))),
-                ),
+            guard: (
+                header(h::SEC_WEBSOCKET_VERSION, header::case_sensitive(b"13")),
+                header(h::CONNECTION, header::contains(header::tag(b"upgrade"))),
+                header(h::UPGRADE, header::contains(header::tag(b"websocket"))),
             ),
         }
     }
@@ -161,12 +155,13 @@ impl<T> Ws<T> {
 impl<T> Ws<T> {
     #[inline]
     fn validate(&self, headers: &HeaderMap) -> Result<Base64EncodedDigest, UpgradeError> {
-        self.guard
-            .cmp(headers)
-            .and_then(|_| match headers.get(h::SEC_WEBSOCKET_KEY) {
+        self.guard.cmp(headers).map_or_else(
+            |error| Err(error.into()),
+            |_| match headers.get(h::SEC_WEBSOCKET_KEY) {
                 Some(key) => sha1(key.as_bytes()),
                 None => Err(UpgradeError::SecWebsocketKey),
-            })
+            },
+        )
     }
 }
 

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -51,7 +51,7 @@ fn configure<T>(listener: &mut Arc<Listener<T>>) -> &mut WsConfig {
 }
 
 #[cfg(feature = "tokio-tungstenite")]
-async fn open<App>(
+async fn handshake<App>(
     request: &mut Request<App>,
     config: &WsConfig,
 ) -> Result<WebSocketStream<UpgradedIo>, Error> {
@@ -68,7 +68,7 @@ async fn open<App>(
 }
 
 #[cfg(all(feature = "tokio-websockets", not(feature = "tokio-tungstenite")))]
-async fn open<App>(
+async fn handshake<App>(
     request: &mut Request<App>,
     config: &WsConfig,
 ) -> Result<WebSocketStream<UpgradedIo>, Error> {
@@ -89,7 +89,7 @@ where
     T: Fn(Channel, Request<App>) -> Await + Send,
     Await: Future<Output = super::Result> + Send + 'static,
 {
-    let err = match open(&mut request, &listener.config).await {
+    let err = match handshake(&mut request, &listener.config).await {
         Err(error) => Some(error),
         Ok(stream) => {
             let task = RunTask::new(listener, request, stream);

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -2,6 +2,7 @@ use http::StatusCode;
 use http::header::{self as h, HeaderMap};
 use std::future::Future;
 use std::sync::Arc;
+use tokio::task::coop::unconstrained;
 
 #[cfg(feature = "tokio-tungstenite")]
 use tokio_tungstenite::{
@@ -89,7 +90,7 @@ where
     T: Fn(Channel, Request<App>) -> Await + Send,
     Await: Future<Output = super::Result> + Send + 'static,
 {
-    let err = match handshake(&mut request, &listener.config).await {
+    let err = match unconstrained(handshake(&mut request, &listener.config)).await {
         Err(error) => Some(error),
         Ok(stream) => {
             let task = RunTask::new(listener, request, stream);


### PR DESCRIPTION
Refactors the websocket upgrade flow to be as clean as possible (at times, paradoxically). This PR does not change the functionality of the websocket upgrade in any way.

Instead, it does the following:

- Sequences upgrade steps to avoid creating signals through explicit state transitions that can be observed outside the application
  - Prefers a uniform allocation size instead of different sized allocations that indicate an error occurring during a validation step
  - Defers different sized allocations that occur for errors vs. responses into the returned BoxFuture to utilize the natural timing entropy from the runtime 

- Obfuscates critical upgrade steps with noisy or entropic operations 
  - The request envelope arc allocation occurs after the response is built rather than before (allocator entropy makes timing non deterministic)
  - The actual upgrade handshake occurs adjacent to a bunch of memcpys drowning out any signal that comes from a move with noise

- Makes the spawned reactor task an async function to make it obvious to the reader what is moved into the spawned task

- Enforces parity between the configuration used by both ws backends
  - `buffer_size == frame_size == max_message_size` limits the number of I/O syscalls per wake to be the amount required to receive, send, and flush a single message while preferring the smallest reasonable buffer size to limit the severity of a leak if the worst case scenario occurs

- Makes the actual upgrade handshake future unconstrained to prevent a connection that is ready for upgrade from yielding to the runtime

