### PR TITLE
style(via): ref map_fn before cmp in guard::MapErr::cmp

### DIFF
--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -148,7 +148,8 @@ where
     type Error<'a> = E;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
-        self.1.cmp(input).map_err(&self.0)
+        let map_fn = &self.0;
+        self.1.cmp(input).map_err(map_fn)
     }
 }
 


### PR DESCRIPTION
Builds references in sequence in `guard::map_err` to match the instructions that are likely generated for `guard::on`.