### PR TITLE
refactor(via): ws::Request delegates to Envelope

### DIFF
--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -14,7 +14,6 @@ async fn hello(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
     // ownership of the request to the next middleware. In this example, we are
     // using the signed cookie jar to store and retrieve the "counter" cookie.
     let mut counter = request
-        .envelope()
         .cookies()
         .signed(&app.secret)
         .get("counter")

--- a/via/src/next.rs
+++ b/via/src/next.rs
@@ -40,9 +40,7 @@ impl<App> Next<App> {
     /// use via::{Request, Next};
     ///
     /// async fn logger(request: Request, next: Next) -> via::Result {
-    ///     let head = request.envelope();
-    ///
-    ///     println!("{} -> {}", head.method(), head.uri().path());
+    ///     println!("{} -> {}", request.method(), request.uri().path());
     ///     next.call(request).await.inspect(|response| {
     ///         println!("<- {}", response.status());
     ///     })

--- a/via/src/request/mod.rs
+++ b/via/src/request/mod.rs
@@ -161,13 +161,8 @@ impl<App> Request<App> {
         self.app.clone()
     }
 
-    #[inline]
-    pub fn envelope(&self) -> &Envelope {
-        &self.envelope
-    }
-
     delegate! {
-        to self.envelope() {
+        to self.envelope {
             /// Returns a reference to the request's method.
             pub fn method(&self) -> &Method;
 
@@ -179,33 +174,19 @@ impl<App> Request<App> {
 
             /// Returns a reference to the request's headers.
             pub fn headers(&self) -> &HeaderMap;
-        }
-    }
 
-    /// Returns reference to the cookies associated with the request.
-    #[inline]
-    pub fn cookies(&self) -> &CookieJar {
-        self.envelope().cookies()
-    }
+            /// Returns reference to the cookies associated with the request.
+            pub fn cookies(&self) -> &CookieJar;
 
-    /// Returns a mutable reference to the cookies associated with the request.
-    pub fn cookies_mut(&mut self) -> &mut CookieJar {
-        self.envelope.cookies_mut()
-    }
+            /// Returns a mutable reference to the cookies associated with the request.
+            pub fn cookies_mut(&mut self) -> &mut CookieJar;
 
-    /// Returns a reference to the associated extensions.
-    pub fn extensions(&self) -> &Extensions {
-        self.envelope().extensions()
-    }
+            /// Returns a reference to the associated extensions.
+            pub fn extensions(&self) -> &Extensions;
 
-    /// Returns a mutable reference to the associated extensions.
-    #[inline]
-    pub fn extensions_mut(&mut self) -> &mut Extensions {
-        self.envelope.extensions_mut()
-    }
+            /// Returns a mutable reference to the associated extensions.
+            pub fn extensions_mut(&mut self) -> &mut Extensions;
 
-    delegate! {
-        to self.envelope() {
             /// Returns reference to the cookies associated with the request.
             pub fn param<'b>(&self, name: &'b str) -> PathParam<'_, 'b>;
 
@@ -239,7 +220,7 @@ impl<App> Request<App> {
 impl<App> Debug for Request<App> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("Request")
-            .field("envelope", self.envelope())
+            .field("envelope", &self.envelope)
             .field("body", &self.body)
             .field("app", &self.app)
             .finish()

--- a/via/src/router/allow.rs
+++ b/via/src/router/allow.rs
@@ -232,7 +232,7 @@ impl<App> Middleware<App> for Deny {
     fn call(&self, request: Request<App>, _: Next<App>) -> BoxFuture {
         let error = Error::method_not_allowed(MethodNotAllowed {
             allow: self.allow,
-            method: request.envelope().method().into(),
+            method: request.method().into(),
         });
 
         Box::pin(async { Err(error) })

--- a/via/src/router/route.rs
+++ b/via/src/router/route.rs
@@ -219,18 +219,18 @@ impl<'a, App> Route<'a, App> {
     /// # Example
     ///
     /// ```
-    /// # use via::{Next, Request, deny};
+    /// # use via::{Next, Request, cookies, deny};
     /// # let mut app = via::app(());
     /// #
     /// // Provides application-wide support for request and response cookies.
-    /// app.middleware(via::cookies(["is-admin"]));
+    /// app.middleware(cookies(["is-admin"]));
     ///
     /// // Requests made to /admin or any of its descendants must have an
     /// // is-admin cookie present on the request.
     /// app.route("/admin").middleware(async |request: Request, next: Next| {
     ///     // We suggest using signed cookies to prevent tampering.
     ///     // See the cookies example in our git repo for more information.
-    ///     if request.envelope().cookies().get("is-admin").is_none() {
+    ///     if request.cookies().get("is-admin").is_none() {
     ///         deny!(401);
     ///     }
     ///

--- a/via/src/ws/request.rs
+++ b/via/src/ws/request.rs
@@ -1,8 +1,13 @@
+use cookie::CookieJar;
+use delegate::delegate;
+use http::{Extensions, HeaderMap, Method, Uri, Version};
 use hyper::upgrade::OnUpgrade;
 use std::sync::Arc;
 
 use crate::app::Shared;
-use crate::request::Envelope;
+use crate::error::Error;
+use crate::request::params::PathParam;
+use crate::request::{Envelope, PathParams, QueryParams};
 
 #[derive(Debug)]
 pub struct Request<App = ()> {
@@ -16,12 +21,43 @@ impl<App> Request<App> {
         &self.app
     }
 
-    pub fn envelope(&self) -> &Envelope {
-        &self.envelope
-    }
-
     pub fn app_owned(&self) -> Shared<App> {
         self.app.clone()
+    }
+
+    delegate! {
+        to self.envelope {
+            /// Returns a reference to the request's method.
+            pub fn method(&self) -> &Method;
+
+            /// Returns a reference to the request's URI.
+            pub fn uri(&self) -> &Uri;
+
+            /// Returns the HTTP version that was used to make the request.
+            pub fn version(&self) -> Version;
+
+            /// Returns a reference to the request's headers.
+            pub fn headers(&self) -> &HeaderMap;
+
+            /// Returns reference to the cookies associated with the request.
+            pub fn cookies(&self) -> &CookieJar;
+
+            /// Returns a reference to the associated extensions.
+            pub fn extensions(&self) -> &Extensions;
+
+            /// Returns a convenient wrapper around an optional reference to
+            /// the path parameter in the request's uri with the provided `name`.
+            pub fn param<'b>(&self, name: &'b str) -> PathParam<'_, 'b>;
+
+            pub fn query<'a, T>(&'a self) -> crate::Result<T>
+            where
+                T: TryFrom<QueryParams<'a>, Error = Error>;
+
+            pub fn params<'a, T>(&'a self) -> crate::Result<T>
+            where
+                T: TryFrom<PathParams<'a>>,
+                Error: From<T::Error>;
+        }
     }
 }
 


### PR DESCRIPTION
Uses method delegation rather than exposing the request's envelope as part of the public API of `Request` and `ws::Request`. This limits the scope of what `Envelope` is used for to _one of_ it's only reason for existing. Storing metadata adjacent to the data from which it is derived.