### PR TITLE
feat(via): http method mask is a u8 for obfuscation

### DIFF
--- a/via/src/lib.rs
+++ b/via/src/lib.rs
@@ -63,7 +63,7 @@ pub use middleware::{BoxFuture, Middleware, Result};
 pub use next::{Continue, Next};
 pub use request::{Payload, Request};
 pub use response::{Finalize, Response};
-pub use router::{connect, delete, get, head, options, patch, post, put, trace};
+pub use router::{delete, get, head, options, patch, post, put, trace};
 pub use server::Server;
 
 #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]

--- a/via/src/router/allow.rs
+++ b/via/src/router/allow.rs
@@ -31,16 +31,15 @@ pub(crate) struct MethodNotAllowed {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    struct Mask: u16 {
-        const CONNECT = 1 << 0;
-        const DELETE  = 1 << 1;
-        const GET     = 1 << 2;
-        const HEAD    = 1 << 3;
-        const OPTIONS = 1 << 4;
-        const PATCH   = 1 << 5;
-        const POST    = 1 << 6;
-        const PUT     = 1 << 7;
-        const TRACE   = 1 << 8;
+    struct Mask: u8 {
+        const DELETE  = 1 << 0;
+        const GET     = 1 << 1;
+        const HEAD    = 1 << 2;
+        const OPTIONS = 1 << 3;
+        const PATCH   = 1 << 4;
+        const POST    = 1 << 5;
+        const PUT     = 1 << 6;
+        const TRACE   = 1 << 7;
     }
 }
 
@@ -77,7 +76,6 @@ macro_rules! methods {
 }
 
 methods! {
-    pub fn connect(CONNECT);
     pub fn delete(DELETE);
     pub fn get(GET);
     pub fn head(HEAD);
@@ -90,7 +88,6 @@ methods! {
 
 impl<T, U> Branch<T, U> {
     methods! {
-        pub fn connect(self, CONNECT);
         pub fn delete(self, DELETE);
         pub fn get(self, GET);
         pub fn head(self, HEAD);
@@ -136,7 +133,6 @@ impl<T, U> Branch<T, U> {
 impl Mask {
     fn as_str(&self) -> Option<&str> {
         match *self {
-            Mask::CONNECT => Some("CONNECT"),
             Mask::DELETE => Some("DELETE"),
             Mask::GET => Some("GET"),
             Mask::HEAD => Some("HEAD"),
@@ -242,7 +238,6 @@ impl<App> Middleware<App> for Deny {
 impl From<&'_ http::Method> for Mask {
     fn from(method: &http::Method) -> Self {
         match *method {
-            http::Method::CONNECT => Mask::CONNECT,
             http::Method::DELETE => Mask::DELETE,
             http::Method::GET => Mask::GET,
             http::Method::HEAD => Mask::HEAD,

--- a/via/src/router/allow.rs
+++ b/via/src/router/allow.rs
@@ -32,12 +32,12 @@ pub(crate) struct MethodNotAllowed {
 bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     struct Mask: u8 {
-        const DELETE  = 1 << 0;
-        const GET     = 1 << 1;
+        const GET     = 1 << 0;
+        const POST    = 1 << 1;
         const HEAD    = 1 << 2;
         const OPTIONS = 1 << 3;
         const PATCH   = 1 << 4;
-        const POST    = 1 << 5;
+        const DELETE  = 1 << 5;
         const PUT     = 1 << 6;
         const TRACE   = 1 << 7;
     }


### PR DESCRIPTION
This PR removes the connect method from http method based routing helpers. If you were using the `via::connect` fn, you can write a custom guard and flat_map it your middleware.

```rust
use http::Method;
use std::process::ExitCode;
use via::{Error, Next, Request, Server, guard};

#[tokio::main]
async fn main() -> Result<ExitCode, Error> {
    let mut app = via::app(());

    app.route("/connect").to(guard::flat_map(
        guard::map_err(
            |_| via::err!(405, "method not allowed."),
            |request: &Request| request.method() == Method::CONNECT,
        ),
        async |_: Request, _: Next| {
            todo!();
        },
    ));

    Server::new(app).listen(("127.0.0.1", 8080)).await
}
```

The reason why we are removing the `via::connect` fn is to obfuscate the signal that comes from a bitwise operation on a `u16`. In addition to `u8` being hard to recognize in a sea of bytes, it's also the size of the mask used in both uses of `tokio::select` in the accept loop and connection task respectively.

In addition to making the data type and value harder to recognize for the mask used to route dynamically dispatched middleware, this also makes it impossible to tell the difference between a GET or POST being routing to a middleware and polling a future in a `tokio::select` arm.

