### PR TITLE
docs(via): exclude *tls features in doc builds

### DIFF
--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -105,4 +105,4 @@ optional = true
 default-features = false
 
 [package.metadata.docs.rs]
-features = ["file", "native-tls", "ring", "rustls-23", "tokio-tungstenite"]
+features = ["file", "ring", "tokio-tungstenite"]


### PR DESCRIPTION
Excludes `native-tls` and `rustls-23` from doc builds. This prevents a conflict between mutually exclusive feature flags for the concrete `IoStream` type exported from `mod server`.

Example usage can be found in the examples directory of this repository.

- [native-tls](https://github.com/via-rs/via/tree/main/examples/native-tls)
- [rustls](https://github.com/via-rs/via/tree/main/examples/rustls)

Also, if you have any questions ask away in our [discord](https://discord.gg/yWvSdsXQ9a).