### PR TITLE
fix(via): tokio-websockets handshake fails to compile

### DIFF
--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -73,7 +73,7 @@ async fn handshake<App>(
     use tokio_websockets::{Config, Limits, server::Builder};
 
     let on_upgrade = request.on_upgrade.take().expect("already upgraded.");
-    let upgraded = UpgradedIo::new(on_upgrade.await?);
+    let upgraded = UpgradedIo::new(on_upgrade.await?)?;
     let limits = Limits::default().max_payload_len(config.max_message_size);
     let config = Config::default()
         .frame_size(config.max_frame_size.unwrap_or(DEFAULT_FRAME_SIZE))


### PR DESCRIPTION
Fixes a bug that prevents applications from compiling when the tokio-websockets feature is enabled. 