### PR TITLE
fix(via): rustls should not allocate in accept

### DIFF
--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -114,8 +114,8 @@ where
             let handshake = acceptor.accept(io);
 
             // native-tls task size: 1952
-            // rustls task size: 1712
-            let task = async move {
+            // rustls task size: 1752
+            async move {
                 let io = timeout(service.config().tls_handshake_timeout(), handshake).await??;
 
                 if *io.preferred_alpn() == Alpn::HTTP_2 {
@@ -129,10 +129,7 @@ where
 
                     serve.await
                 }
-            };
-
-            println!("task size = {}", std::mem::size_of_val(&task));
-            task
+            }
         });
 
         // task size: 928

--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -115,7 +115,7 @@ where
 
             // native-tls task size: 1952
             // rustls task size: 1712
-            async move {
+            let task = async move {
                 let io = timeout(service.config().tls_handshake_timeout(), handshake).await??;
 
                 if *io.preferred_alpn() == Alpn::HTTP_2 {
@@ -129,7 +129,10 @@ where
 
                     serve.await
                 }
-            }
+            };
+
+            println!("task size = {}", std::mem::size_of_val(&task));
+            task
         });
 
         // task size: 928

--- a/via/src/server/tls/rustls.rs
+++ b/via/src/server/tls/rustls.rs
@@ -42,12 +42,15 @@ impl Acceptor for RustlsAcceptor {
         &self,
         io: TcpStream,
     ) -> impl Future<Output = Result<Self::Stream, Self::Error>> + Send + 'static {
-        let mut tls = Box::pin(MaybeTlsStream {
-            state: ReadyState::Handshake(self.0.accept(io)),
-        });
+        let acceptor = self.0.clone();
 
         async move {
+            let mut tls = Box::pin(MaybeTlsStream {
+                state: ReadyState::Handshake(acceptor.accept(io)),
+            });
+
             let alpn = (&mut tls).await?;
+
             Ok(RustlsStream { alpn, tls })
         }
     }


### PR DESCRIPTION
Fixes a regression where the rustls implementation allocates in accept. This change prefers cloning the arc containing the inner rustls acceptor twice rather allocating in the main thread of the accept loop. This regression was likely only noticeable for users with applications that are frequently at capacity.