### PR TITLE
style(via): native-tls alpn match is consistent with rustls

### DIFF
--- a/via/src/server/tls/native.rs
+++ b/via/src/server/tls/native.rs
@@ -41,11 +41,11 @@ impl Acceptor for NativeTlsAcceptor {
 
         async move {
             let stream = acceptor.accept(io).await?;
-            let alpn = stream
-                .get_ref()
-                .negotiated_alpn()?
-                .and_then(|negotiated| (negotiated == b"h2").then_some(Alpn::HTTP_2))
-                .unwrap_or(Alpn::HTTP_11);
+            let inner = stream.get_ref();
+            let alpn = match inner.negotiated_alpn()? {
+                Some(value) if value == b"h2" => Alpn::HTTP_2,
+                _ => Alpn::HTTP_11,
+            };
 
             Ok(NativeTlsStream { alpn, stream })
         }


### PR DESCRIPTION
Updates the native-tls alpn extraction to match the way we do it in the rustls implementation.