### PR TITLE
refactor(via): content is a predicate

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::process::ExitCode;
-use via::guard::{self, header::media};
-use via::{Next, Payload, Request, Response, Server, rescue};
+use via::guard::{content, header::media};
+use via::{Next, Payload, Request, Response, Server, guard, rescue};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Document<T> {
@@ -41,7 +41,7 @@ async fn main() -> via::Result<ExitCode> {
     app.middleware(rescue(|error| error.use_json()));
 
     // If the client does not speak JSON, deny the request.
-    app.middleware(guard::content(media::json(), media::json()));
+    app.middleware(guard(content(media::json(), media::json())));
 
     // Define a route that responds to POST /hello.
     app.route("/hello").to(via::post(hello).or_deny());

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -23,6 +23,7 @@ pub type Content<T, U> = (
 ///
 /// ```no_run
 /// use std::process::ExitCode;
+/// use via::guard::method;
 /// use via::{Request, Next, Server, guard};
 ///
 /// async fn cache(request: Request, next: Next) -> via::Result {
@@ -34,7 +35,7 @@ pub type Content<T, U> = (
 ///     let mut app = via::app(());
 ///
 ///     // Non-idempotent requests will run the cache middleware.
-///     app.middleware(guard::filter(guard::method::is_safe(), cache));
+///     app.middleware(guard::filter(method::is_safe(), cache));
 ///
 ///     Server::new(app).listen(("127.0.0.1", 8080)).await
 /// }
@@ -76,13 +77,14 @@ pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
 /// # Example
 ///
 /// ```rust
-/// use via::guard::{self, header::media};
+/// use via::guard::{content, header::media};
+/// use via::guard;
 ///
 /// let mut app = via::app(());
 /// let mut api = app.route("/api");
 ///
 /// // If the client does not speak JSON, deny the request.
-/// api.middleware(guard::content(media::json(), media::json()));
+/// api.middleware(guard(content(media::json(), media::json())));
 ///
 /// // Subsequent routes defined from `api` require:
 /// //   - Accept: application/json, */*

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -113,14 +113,14 @@ where
 ///
 /// The first argument is what the client is allowed to send. The second
 /// argument is how the server will reply.
-pub fn content<T, U>(accepts: T, provides: U) -> FlatMap<Content<T, U>, Continue> {
-    guard((
+pub fn content<T, U>(accepts: T, provides: U) -> Content<T, U> {
+    (
         header::accept(provides),
         when(
             method::is_mutation(),
             (header::content_type(accepts), header::content_length()),
         ),
-    ))
+    )
 }
 
 impl<T, U, App> Middleware<App> for FlatMap<T, U>


### PR DESCRIPTION
Refactors `guard::content` to return a `Predicate` so it's easier to compose with other guards. Many applications can benefit from merging their content guard with another `Middleware` that is applied to a router namespace. Doing so prevents an additional atomic operation and frees an entry in `Next`. 