### PR TITLE
feat(via): impl ws::ResultExt for Error

### DIFF
--- a/via/src/ws/error.rs
+++ b/via/src/ws/error.rs
@@ -79,6 +79,18 @@ impl From<DenyHeader<'_>> for UpgradeError {
     }
 }
 
+impl ResultExt for Error {
+    type Output = ();
+
+    fn or_close(self) -> Result<Self::Output> {
+        Err(ControlFlow::Break(self))
+    }
+
+    fn or_reconnect(self) -> Result<Self::Output> {
+        Err(ControlFlow::Continue(self))
+    }
+}
+
 impl<T, E> ResultExt for std::result::Result<T, E>
 where
     Error: From<E>,


### PR DESCRIPTION
Implements `ws::ResultExt` for `Error`. This is a convenience for cases where you want to return an error but don't want to import `std::ops::ControlFlow` and compose the error type for `ws::Result` yourself.

```rust
let Some(mut session) = request.session().cloned() else {
    return via::err!(401, "unauthorized.").or_close();
};
```