### PR TITLE
style(via): let map_fn unnecessary in guard::map_err

### DIFF
--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -148,8 +148,7 @@ where
     type Error<'a> = E;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
-        let map_fn = &self.0;
-        self.1.cmp(input).map_err(map_fn)
+        self.1.cmp(input).map_err(&self.0)
     }
 }
 


### PR DESCRIPTION
The let binding to the closure passed to `map_err` in the implementation of `Predicate for MapErr<_, _>`  is unnecessary. This PR removes it.