### PR TITLE
chore(via): v2.0.0-gm.48 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-gm.47"
+via = "2.0.0-gm.48"
 http = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```

--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-gm.47"
+version = "2.0.0-gm.48"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Updates the version of Via to v2.0.0-gm.48 in preparation for release.

---

## Changelog

- #551
