### PR TITLE
refactor(via): zeroization helpers in trait Payloadz

### DIFF
--- a/via/src/request/mod.rs
+++ b/via/src/request/mod.rs
@@ -4,7 +4,7 @@ mod payload;
 mod query;
 
 pub use params::{PathParams, QueryParams};
-pub use payload::{Aggregate, Coalesce, Payload, RequestBody};
+pub use payload::{Aggregate, Coalesce, Payload, Payloadz, RequestBody};
 
 use cookie::CookieJar;
 use delegate::delegate;

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -104,7 +104,7 @@ pub trait Payloadz: Payload {
     ///
     /// If zeroization is impossible due to non-unique access of an underlying
     /// frame buffer, `self` is returned to the caller. This allows users to
-    /// yield to the runtime and retry zeriozation, add `connection: close` to
+    /// yield to the runtime and retry zeriozation, add `Connection: close` to
     /// the response header, or panic.
     fn z_json<T>(self) -> Result<Result<T, Error>, Self>
     where
@@ -127,7 +127,7 @@ pub trait Payloadz: Payload {
     ///
     /// If zeroization is impossible due to non-unique access of an underlying
     /// frame buffer, `self` is returned to the caller. This allows users to
-    /// yield to the runtime and retry zeriozation, add `connection: close` to
+    /// yield to the runtime and retry zeriozation, add `Connection: close` to
     /// the response header, or panic.
     fn z_utf8(self) -> Result<Result<String, Error>, Self> {
         self.z_coalesce().map(deserialize_utf8)

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -69,35 +69,27 @@ pub trait Payload: sealed::Sealed + Sized {
 
 /// The zeroizing version of the [`Payload`] trait.
 ///
-/// The majority of use-cases where zeroization is preferred but not strictly
-/// necessary can benefit from using the `be_z_*` prefixed versions of the
-/// methods defined in the [`Payloadz`] trait. The `be_z` prefix stands for
-/// "best-effort zeroization". If zeroization is impossible due to non-unique
-/// access of a buffer contained in the payload, `be_z_*` variations fall back
-/// to their non-zeroing counterparts.
+/// Unique access to each frame of the payload is required for safe
+/// zeroization. If zeroization is a hard requirement, we recommend defining a
+/// policy that is sufficient for your business use-case. For example, yielding
+/// to runtime and retrying reads when unique access is guaranteed is a viable
+/// option for many use-cases. If retaining an unzeroed secret in memory is too
+/// risky for your use-case, you can chose to continue processing the request
+/// and add a `Connection: close` header to the response or panic to ensure
+/// that the memory gets reclaimed by the OS as soon as possible.
 ///
-/// If zeroization is a hard requirement, we recommend defining a policy that
-/// is sufficient for your business use-case. For example, returning an opaque
-/// 500 error to the client and immediately stopping request processing is
-/// likely enough to satisfy the definition of "fair handling of user data". As
-/// always, we suggest defining a policy and working with compliance and legal
-/// to determine what is right for your situation.
-///
-/// In any case, users should avoid retaining the payload returned in the `Err`
-/// branch of strict zeroizing methods prefixed by `z_*` and stop processing
-/// the request as soon as possible. This reduces the likelihood of a panic
-/// crashing a connection task, potentially (albeit unlikely) exposing
-/// un-zeroed memory.
+/// Most of our users just want to do the right thing and zeroize "secrets"
+/// such as a password in request payloads when possible. In these cases, it's
+/// probably best to avoid decision fatigue and use a "best effort" variation
+/// of the function (prefixed by `be_z_*`). They fall back to their non-zeroing
+/// counterparts if unique access is not guarateed.
 pub trait Payloadz: Payload {
     /// Coalesces all non-contiguous bytes into a single contiguous `Vec<u8>`.
     ///
     /// If zeroization is impossible due to non-unique access of an underlying
-    /// frame buffer, `self` is returned to the caller.
-    ///
-    /// # Security
-    ///
-    /// Users should avoid retaining the returned `Self` in `Err` longer than
-    /// necessary, as it contains un-zeroed memory.
+    /// frame buffer, `self` is returned to the caller. This allows users to
+    /// yield to the runtime and retry zeriozation, add `connection: close` to
+    /// the response header, or panic.
     fn z_coalesce(self) -> Result<Vec<u8>, Self>;
 
     /// Deserialize the payload as JSON into the specified type `T`, zeroizing
@@ -108,10 +100,12 @@ pub trait Payloadz: Payload {
     /// - `Err(Self)` if zeroization is impossible due to non-unique access
     /// - `Ok(Err(Error))` if `T` cannot be deserialized from the data in `self`
     ///
-    /// # Security
+    /// ## Unique Access
     ///
-    /// Users should avoid retaining the returned `Self` in `Err` longer than
-    /// necessary, as it contains un-zeroed memory.
+    /// If zeroization is impossible due to non-unique access of an underlying
+    /// frame buffer, `self` is returned to the caller. This allows users to
+    /// yield to the runtime and retry zeriozation, add `connection: close` to
+    /// the response header, or panic.
     fn z_json<T>(self) -> Result<Result<T, Error>, Self>
     where
         T: DeserializeOwned,
@@ -128,6 +122,13 @@ pub trait Payloadz: Payload {
     /// - `Err(Self)` if zeroization is impossible due to non-unique access
     /// - `Ok(Err(Error))` if the payload contains an invalid UTF-8 byte
     ///   sequence
+    ///
+    /// ## Unique Access
+    ///
+    /// If zeroization is impossible due to non-unique access of an underlying
+    /// frame buffer, `self` is returned to the caller. This allows users to
+    /// yield to the runtime and retry zeriozation, add `connection: close` to
+    /// the response header, or panic.
     fn z_utf8(self) -> Result<Result<String, Error>, Self> {
         self.z_coalesce().map(deserialize_utf8)
     }
@@ -323,38 +324,6 @@ impl Payload for Aggregate {
 }
 
 impl Payloadz for Aggregate {
-    fn z_json<T>(mut self) -> Result<Result<T, Error>, Self>
-    where
-        T: DeserializeOwned,
-    {
-        if let [frame] = self.payload.frames_mut() {
-            // If we do not have unique access to self, return back to the caller.
-            if !frame.is_unique() {
-                return Err(self);
-            }
-
-            // Attempt to deserialize `T` from the bytes in self.
-            let result = deserialize_json(frame.as_ref());
-
-            // Safety:
-            //
-            // The precondition at the top of this function ensures that we
-            // have unique access to self and therefore, can mutate the buffer.
-            unsafe {
-                unfenced_zeroize(frame);
-            }
-
-            // Ensures sequential access to the buffers contained in self.
-            // A necessary step after zeroization.
-            release_compiler_fence();
-
-            return Ok(result);
-        }
-
-        self.z_coalesce()
-            .map(|data| deserialize_json(data.as_slice()))
-    }
-
     fn z_coalesce(mut self) -> Result<Vec<u8>, Self> {
         let mut dest = self.len().map(Vec::with_capacity).unwrap_or_default();
         let payload = &mut self.payload;
@@ -390,6 +359,38 @@ impl Payloadz for Aggregate {
         release_compiler_fence();
 
         Ok(dest)
+    }
+
+    fn z_json<T>(mut self) -> Result<Result<T, Error>, Self>
+    where
+        T: DeserializeOwned,
+    {
+        if let [frame] = self.payload.frames_mut() {
+            // If we do not have unique access to self, return back to the caller.
+            if !frame.is_unique() {
+                return Err(self);
+            }
+
+            // Attempt to deserialize `T` from the bytes in self.
+            let result = deserialize_json(frame.as_ref());
+
+            // Safety:
+            //
+            // The precondition at the top of this function ensures that we
+            // have unique access to self and therefore, can mutate the buffer.
+            unsafe {
+                unfenced_zeroize(frame);
+            }
+
+            // Ensures sequential access to the buffers contained in self.
+            // A necessary step after zeroization.
+            release_compiler_fence();
+
+            return Ok(result);
+        }
+
+        self.z_coalesce()
+            .map(|data| deserialize_json(data.as_slice()))
     }
 }
 

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -67,7 +67,7 @@ pub trait Payload: sealed::Sealed + Sized {
     }
 }
 
-/// The zeroizing version of the [`Payload`] trait.
+/// Zeroizing variations of the functions provided in `Payload`.
 ///
 /// Unique access to each frame of the payload is required for safe
 /// zeroization. If zeroization is a hard requirement, we recommend defining a

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -69,6 +69,28 @@ pub trait Payload: sealed::Sealed + Sized {
     ///
     fn coalesce(self) -> Vec<u8>;
 
+    /// Deserialize the payload as JSON into the specified type `T`.
+    ///
+    /// # Errors
+    ///
+    /// - `Err(Error)` if `T` cannot be deserialized from the data in `self`
+    ///
+    fn json<T>(self) -> Result<T, Error>
+    where
+        T: DeserializeOwned;
+
+    /// Converts the payload into a UTF-8 `String`.
+    ///
+    /// # Errors
+    ///
+    /// - `Err(Error)` if the payload contains an invalid UTF-8 byte sequence
+    ///
+    fn utf8(self) -> Result<String, Error> {
+        deserialize_utf8(self.coalesce())
+    }
+}
+
+pub trait Payloadz: Payload {
     /// Coalesces all non-contiguous bytes into a single contiguous `Vec<u8>`.
     ///
     /// If zeroization is impossible due to non-unique access of an underlying
@@ -80,16 +102,6 @@ pub trait Payload: sealed::Sealed + Sized {
     /// necessary, as it contains un-zeroed memory.
     ///
     fn z_coalesce(self) -> Result<Vec<u8>, Self>;
-
-    /// Deserialize the payload as JSON into the specified type `T`.
-    ///
-    /// # Errors
-    ///
-    /// - `Err(Error)` if `T` cannot be deserialized from the data in `self`
-    ///
-    fn json<T>(self) -> Result<T, Error>
-    where
-        T: DeserializeOwned;
 
     /// Deserialize the payload as JSON into the specified type `T`, zeroizing
     /// the original data from which the `T` is deserialized.
@@ -112,33 +124,6 @@ pub trait Payload: sealed::Sealed + Sized {
             .map(|data| deserialize_json(data.as_slice()))
     }
 
-    /// Deserialize the payload as JSON into the specified type `T`, zeroizing
-    /// the original data from which the `T` is deserialized.
-    ///
-    /// If zeroization is impossible due to non-unique access, fallback to
-    /// [`Payload::json`].
-    ///
-    /// # Errors
-    ///
-    /// - `Err(Error)` if `T` cannot be deserialized from the data in `self`
-    ///
-    fn bez_json<T>(self) -> Result<T, Error>
-    where
-        T: DeserializeOwned,
-    {
-        self.z_json().unwrap_or_else(Self::json)
-    }
-
-    /// Converts the payload into a UTF-8 `String`.
-    ///
-    /// # Errors
-    ///
-    /// - `Err(Error)` if the payload contains an invalid UTF-8 byte sequence
-    ///
-    fn utf8(self) -> Result<String, Error> {
-        deserialize_utf8(self.coalesce())
-    }
-
     /// Converts the payload into a UTF-8 `String`, zeroizing the original data
     /// from which the `String` is constructed.
     ///
@@ -152,6 +137,23 @@ pub trait Payload: sealed::Sealed + Sized {
         self.z_coalesce().map(deserialize_utf8)
     }
 
+    /// Deserialize the payload as JSON into the specified type `T`, zeroizing
+    /// the original data from which the `T` is deserialized.
+    ///
+    /// If zeroization is impossible due to non-unique access, fallback to
+    /// [`Payload::json`].
+    ///
+    /// # Errors
+    ///
+    /// - `Err(Error)` if `T` cannot be deserialized from the data in `self`
+    ///
+    fn be_z_json<T>(self) -> Result<T, Error>
+    where
+        T: DeserializeOwned,
+    {
+        self.z_json().unwrap_or_else(Self::json)
+    }
+
     /// Converts the payload into a UTF-8 `String`, zeroizing the original data
     /// from which the `String` is constructed.
     ///
@@ -162,7 +164,7 @@ pub trait Payload: sealed::Sealed + Sized {
     ///
     /// - `Err(Error)` if the payload contains an invalid UTF-8 byte sequence
     ///
-    fn bez_utf8(self) -> Result<String, Error> {
+    fn be_z_utf8(self) -> Result<String, Error> {
         self.z_utf8().unwrap_or_else(Self::utf8)
     }
 }
@@ -222,7 +224,6 @@ fn deserialize_utf8(data: Vec<u8>) -> Result<String, Error> {
 ///   2. `compiler_fence` is called after each frame is zeroized
 ///
 /// [zeroize]: https://crates.io/crates/zeroize/
-#[inline(never)]
 unsafe fn unfenced_zeroize(frame: &mut Bytes) {
     let len = frame.remaining();
     let ptr = frame.as_ptr() as *mut u8;
@@ -284,26 +285,11 @@ macro_rules! impl_payload_for_bytes_like {
                 Payload::coalesce(Bytes::from($from(self)))
             }
 
-            fn z_coalesce(self) -> Result<Vec<u8>, Self> {
-                Payload::z_coalesce(Bytes::from($from(self))).map_err($into)
-            }
-
             fn json<T>(self) -> Result<T, Error>
             where
                 T: DeserializeOwned,
             {
                 Payload::json(Bytes::from($from(self)))
-            }
-
-            fn z_json<T>(self) -> Result<Result<T, Error>, Self>
-            where
-                T: DeserializeOwned,
-            {
-                Payload::z_json(Bytes::from($from(self))).map_err($into)
-            }
-
-            fn z_utf8(self) -> Result<Result<String, Error>, Self> {
-                Payload::z_utf8(Bytes::from($from(self))).map_err($into)
             }
         }
     };
@@ -339,7 +325,9 @@ impl Payload for Aggregate {
 
         deserialize_json(self.coalesce().as_slice())
     }
+}
 
+impl Payloadz for Aggregate {
     fn z_json<T>(mut self) -> Result<Result<T, Error>, Self>
     where
         T: DeserializeOwned,
@@ -433,32 +421,6 @@ impl Payload for Bytes {
         dest
     }
 
-    fn z_coalesce(mut self) -> Result<Vec<u8>, Self> {
-        // If we do not have unique access to self, return back to the caller.
-        if !self.is_unique() {
-            return Err(self);
-        }
-
-        let mut dest = Vec::with_capacity(self.remaining());
-
-        // The transport layer sufficiently chunks each frame.
-        dest.extend_from_slice(self.as_ref());
-
-        // Safety:
-        //
-        // The precondition at the top of this function ensures that we
-        // have unique access to self and therefore, can mutate the buffer.
-        unsafe {
-            unfenced_zeroize(&mut self);
-        }
-
-        // Ensures sequential access to the buffers contained in self.
-        // A necessary step after zeroization.
-        release_compiler_fence();
-
-        Ok(dest)
-    }
-
     fn json<T>(mut self) -> Result<T, Error>
     where
         T: DeserializeOwned,
@@ -470,33 +432,6 @@ impl Payload for Bytes {
         self.advance(self.remaining());
 
         result
-    }
-
-    fn z_json<T>(mut self) -> Result<Result<T, Error>, Self>
-    where
-        T: DeserializeOwned,
-    {
-        // If we do not have unique access to self, return back to the caller.
-        if !self.is_unique() {
-            return Err(self);
-        }
-
-        // Attempt to deserialize `T` from the bytes in self.
-        let result = deserialize_json(self.as_ref());
-
-        // Safety:
-        //
-        // The precondition at the top of this function ensures that we
-        // have unique access to self and therefore, can mutate the buffer.
-        unsafe {
-            unfenced_zeroize(&mut self);
-        }
-
-        // Ensures sequential access to the buffers contained in self.
-        // A necessary step after zeroization.
-        release_compiler_fence();
-
-        Ok(result)
     }
 }
 

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -41,29 +41,6 @@ mod sealed {
 /// Payload methods take ownership of `self` to prevent accidental reuse of
 /// volatile buffers. This behavior ensures that once the data is coalesced or
 /// deserialized, the original memory is unreachable.
-///
-/// ## Zeroization
-///
-/// The majority of use-cases where zeroization is preferred but not strictly
-/// necessary can benefit from using the `bez_*` prefixed versions of the
-/// methods defined in the `Payload` trait. The `be_z` prefix stands for
-/// "best-effort zeroization". If zeroization is impossible due to non-unique
-/// access of a buffer contained in the payload, `bez_*` variations fall back
-/// to their non-zeroing counterparts.
-///
-/// If zeroization is a hard requirement, we recommend defining a policy that
-/// is sufficient for your business use-case. For example, returning an opaque
-/// 500 error to the client and immediately stopping request processing is likely
-/// enough to satisfy the definition of "fair handling of user data". As always,
-/// we suggest defining a policy and working with compliance and legal to
-/// determine what is right for your situation.
-///
-/// In any case, users should avoid retaining the payload returned in the `Err`
-/// branch of strict zeroizing methods prefixed by `z_*` and stop processing
-/// the request as soon as possible. This reduces the likelihood of a panic
-/// crashing a connection task, potentially (albeit unlikely) exposing
-/// un-zeroed memory.
-///
 pub trait Payload: sealed::Sealed + Sized {
     /// Coalesces all non-contiguous bytes into a single contiguous `Vec<u8>`.
     ///
@@ -90,6 +67,27 @@ pub trait Payload: sealed::Sealed + Sized {
     }
 }
 
+/// The zeroizing version of the [`Payload`] trait.
+///
+/// The majority of use-cases where zeroization is preferred but not strictly
+/// necessary can benefit from using the `be_z_*` prefixed versions of the
+/// methods defined in the [`Payloadz`] trait. The `be_z` prefix stands for
+/// "best-effort zeroization". If zeroization is impossible due to non-unique
+/// access of a buffer contained in the payload, `be_z_*` variations fall back
+/// to their non-zeroing counterparts.
+///
+/// If zeroization is a hard requirement, we recommend defining a policy that
+/// is sufficient for your business use-case. For example, returning an opaque
+/// 500 error to the client and immediately stopping request processing is
+/// likely enough to satisfy the definition of "fair handling of user data". As
+/// always, we suggest defining a policy and working with compliance and legal
+/// to determine what is right for your situation.
+///
+/// In any case, users should avoid retaining the payload returned in the `Err`
+/// branch of strict zeroizing methods prefixed by `z_*` and stop processing
+/// the request as soon as possible. This reduces the likelihood of a panic
+/// crashing a connection task, potentially (albeit unlikely) exposing
+/// un-zeroed memory.
 pub trait Payloadz: Payload {
     /// Coalesces all non-contiguous bytes into a single contiguous `Vec<u8>`.
     ///
@@ -100,7 +98,6 @@ pub trait Payloadz: Payload {
     ///
     /// Users should avoid retaining the returned `Self` in `Err` longer than
     /// necessary, as it contains un-zeroed memory.
-    ///
     fn z_coalesce(self) -> Result<Vec<u8>, Self>;
 
     /// Deserialize the payload as JSON into the specified type `T`, zeroizing
@@ -115,7 +112,6 @@ pub trait Payloadz: Payload {
     ///
     /// Users should avoid retaining the returned `Self` in `Err` longer than
     /// necessary, as it contains un-zeroed memory.
-    ///
     fn z_json<T>(self) -> Result<Result<T, Error>, Self>
     where
         T: DeserializeOwned,
@@ -132,7 +128,6 @@ pub trait Payloadz: Payload {
     /// - `Err(Self)` if zeroization is impossible due to non-unique access
     /// - `Ok(Err(Error))` if the payload contains an invalid UTF-8 byte
     ///   sequence
-    ///
     fn z_utf8(self) -> Result<Result<String, Error>, Self> {
         self.z_coalesce().map(deserialize_utf8)
     }


### PR DESCRIPTION
This PR moves the zeroization helpers into a separate trait `Payloadz`.

This change is an acknowledgement of reality. We're unable to zeroize websocket messages due to the way that the `Byte` struct shares the underlying allocation with the buffer owned by each respective web socket backend. 

We want to make zeroization easy because it's an important part of a high assurance application. For example, if you are implementing a custom version of AWS Parameter Store or simply want zeroize a request payload containing a user's password it's as simple as using `Payload::be_z_json` instead of `Payload::json`. However, our goal isn't to help users zeroize every buffer that exists in their application. Doing so would be unreasonable.

We do our best to help prevent the worst case scenario with regards to cyber security. We chose to error on the side of caution, avoid hidden buffering, provide sensible helpers to close connections on error, easily add a timeout to aggregating the data in the request body, and make risk explicit and give our users a choice.

We don't claim to be perfect. We understand that we live in a imperfect world and embrace imperfection. We believe that doing otherwise would result in diminishing returns.

These axioms help provide our users with the tools to build resilient software that treat private user data as a matter of life and death. Even under adversarial conditions.