### PR TITLE
feat(via): sec-websocket-accept is valid utf8

### DIFF
--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -180,7 +180,7 @@ where
             let result = Response::build()
                 .status(StatusCode::SWITCHING_PROTOCOLS)
                 .header(h::CONNECTION, "upgrade")
-                .header(h::SEC_WEBSOCKET_ACCEPT, accept.as_str())
+                .header(h::SEC_WEBSOCKET_ACCEPT, accept.as_str()?)
                 .header(h::UPGRADE, "websocket")
                 .finish();
 

--- a/via/src/ws/util/sha1.rs
+++ b/via/src/ws/util/sha1.rs
@@ -28,9 +28,8 @@ pub fn sha1(input: &[u8]) -> Result<Base64EncodedDigest, UpgradeError> {
 }
 
 impl Base64EncodedDigest {
-    #[inline(always)]
-    pub fn as_str(&self) -> &str {
-        // Safety: Base64 is guaranteed to be ASCII and therefore, valid UTF-8.
-        unsafe { str::from_utf8_unchecked(&self.0) }
+    #[inline]
+    pub fn as_str(&self) -> Result<&str, UpgradeError> {
+        str::from_utf8(&self.0).or(Err(UpgradeError::Other))
     }
 }


### PR DESCRIPTION
Reinforces the security of the ws upgrade handshake by validating the utf8-ness of the base64 encoded `sec-websocket-accept` header value.

This is probably unnecessary in most cases but it's such a low cost for added assurance that I wouldn't feel comfortable saying that we are a high assurance web framework without doing such a thing. Encoding also happens once per upgrade so the difference in performance is negligible.