### PR TITLE
chore(via): v2.0.0-gm.50 release

### DIFF
--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-gm.49"
+version = "2.0.0-gm.50"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Updates the version of Via to v2.0.0-gm.50 in preparation for release.

---

## Changelog

- #559
- #557 
- #556
- #555