### PR TITLE
docs(via): update readme version to v2.0.0-gm.50

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-gm.49"
+via = "2.0.0-gm.50"
 http = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```


### PR DESCRIPTION
Last minute update to the README version ahead of release.