### PR TITLE
fix(via): rustls io err if polled mid-handshake

### DIFF
--- a/via/src/server/tls/rustls.rs
+++ b/via/src/server/tls/rustls.rs
@@ -58,16 +58,14 @@ impl Acceptor for RustlsAcceptor {
 
 impl MaybeTlsStream {
     #[inline]
-    fn with_stream<F, T>(mut self: Pin<&mut Self>, f: F) -> Poll<T>
+    fn with_stream<F, T>(mut self: Pin<&mut Self>, f: F) -> Poll<io::Result<T>>
     where
-        F: FnOnce(Pin<&mut TlsStream<TcpStream>>) -> Poll<T>,
+        F: FnOnce(Pin<&mut TlsStream<TcpStream>>) -> Poll<io::Result<T>>,
     {
-        match &mut self.state {
-            ReadyState::Stream(stream) => f(Pin::new(stream)),
-            ReadyState::Handshake(_) => {
-                // TODO: Placeholder for tracing...
-                Poll::Pending
-            }
+        if let ReadyState::Stream(stream) = &mut self.state {
+            f(Pin::new(stream))
+        } else {
+            Poll::Ready(Err(io::ErrorKind::BrokenPipe.into()))
         }
     }
 }


### PR DESCRIPTION
The rustls io stream should never be polled mid-handshake. This PR returns an error `io::ErrorKind::BrokenPipe` if it is polled before the handshake completes. 