### PR TITLE
fix(via): continue on EMFILE only

### DIFF
--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
-use tokio::task::{JoinSet, coop};
+use tokio::task::{self, JoinSet, coop};
 use tokio::time::timeout;
 
 #[cfg(any(feature = "native-tls", feature = "rustls-23"))]
@@ -79,14 +79,10 @@ where
                     log!("error(accept): {}", error);
 
                     #[cfg(unix)]
-                    let Some(12 | 23 | 24) = error.raw_os_error() else {
-                        continue;
-                    };
-
-                    #[cfg(windows)]
-                    let Some(10024 | 10055) = error.raw_os_error() else {
-                        continue;
-                    };
+                    if let Some(24) = error.raw_os_error() { // EMFILE
+                        task::yield_now().await; // We're at capacity.
+                        continue; // Try again after yielding to the runtime.
+                    }
 
                     break ExitCode::FAILURE;
                 }

--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -77,14 +77,41 @@ where
                 Ok(stream) => stream,
                 Err(error) => {
                     log!("error(accept): {}", error);
+                    break cfg_select! {
+                        unix => match error.raw_os_error() {
+                            // ENOMEM or ENFILE
+                            //
+                            // Immutably replacing the node is preferred when
+                            // the process exits with any of these codes.
+                            Some(code @ (12 | 23)) => ExitCode::from(code as u8),
 
-                    #[cfg(unix)]
-                    if let Some(24) = error.raw_os_error() { // EMFILE
-                        tokio::task::yield_now().await; // We're at capacity.
-                        continue; // Try again after yielding to the runtime.
-                    }
+                            // EMFILE
+                            //
+                            // The server is at capacity. Yield to the runtime.
+                            //
+                            // A connection task is likely using an fd that the
+                            // application developer did not account for.
+                            Some(24) => {
+                                tokio::task::yield_now().await;
+                                continue; // Retry after yield.
+                            }
 
-                    break ExitCode::FAILURE;
+                            // All other codes are an opaque error.
+                            //
+                            // Follow the instructions provided for non-POSIX
+                            // systems.
+                            _ => ExitCode::FAILURE,
+                        },
+
+                        // Use an opaque exit code for non-POSIX platforms.
+                        //
+                        // Either restart the process or immutably replace
+                        // the node.
+                        //
+                        // When possible, prefer containerized immutable
+                        // deployments.
+                        _ => ExitCode::FAILURE,
+                    };
                 }
             },
             // A graceful shutdown signal was sent to the process.

--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
-use tokio::task::{self, JoinSet, coop};
+use tokio::task::{JoinSet, coop};
 use tokio::time::timeout;
 
 #[cfg(any(feature = "native-tls", feature = "rustls-23"))]
@@ -80,7 +80,7 @@ where
 
                     #[cfg(unix)]
                     if let Some(24) = error.raw_os_error() { // EMFILE
-                        task::yield_now().await; // We're at capacity.
+                        tokio::task::yield_now().await; // We're at capacity.
                         continue; // Try again after yielding to the runtime.
                     }
 


### PR DESCRIPTION
Reduces the accept errors in which the server continues to listen for new connections to `EMFILE` on POSIX. This enhances security for applications running in hostile environments.

Anyone running an application in a hostile environment should prefer immutably replacing the node rather than simply restarting the server. If a server becomes compromised, replacing the node immutably makes the most sense. The likelihood of an adversary gaining shell access a second time to an entirely new node should be much lower.