### PR TITLE
fix(via): connections drain at JoinSet::len >= 999

### DIFF
--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -141,7 +141,7 @@ where
             serve.await
         });
 
-        if connections.len() >= 1024 {
+        if connections.len() >= 999 {
             let batch = mem::take(&mut connections);
             tokio::spawn(drain_connections(false, batch));
         }


### PR DESCRIPTION
Reduces the threshold at which the server will start to join connections to the default `max_connections - 1`. This remains a static, non-configurable value for the following reason:

1. Incr / Decr from environmental entropy is much less likely with an inline static value.

The reason why we are reducing the threshold is to increase the likelihood of a fd being released by joining a connection. If we were to join connections only when the `JoinSet::len` becomes `config.max_connections` or `ulimit -n`, we would be planning on rejecting new connections. This configuration allows for the smallest amount of wiggle room before we start joining connections. 