### PR TITLE
fix(via): unused warning in drain_connections in release

### DIFF
--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -198,13 +198,17 @@ async fn drain_connections(immediate: bool, mut connections: JoinSet<Result<(), 
     );
 
     while let Some(result) = connections.join_next().await {
+        #[cfg(not(debug_assertions))]
+        let _ = result;
+
+        #[cfg(debug_assertions)]
         match result {
             Ok(Ok(_)) => {}
             Err(error) => {
-                log!(error(connection), "{}", error);
+                log!(error(connection), "{}", &error);
             }
             Ok(Err(error)) => {
-                log!(error(service), "{}", error);
+                log!(error(service), "{}", &error);
             }
         }
 

--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -199,7 +199,7 @@ async fn drain_connections(immediate: bool, mut connections: JoinSet<Result<(), 
 
     while let Some(result) = connections.join_next().await {
         #[cfg(not(debug_assertions))]
-        let _ = result;
+        drop(result);
 
         #[cfg(debug_assertions)]
         match result {


### PR DESCRIPTION
Fixes an unused variable warning in release builds now that `log!` is fully removed in release.