### PR TITLE
docs(via): document public members in mod guard

### DIFF
--- a/via/src/guard/header/mod.rs
+++ b/via/src/guard/header/mod.rs
@@ -108,6 +108,8 @@ where
 }
 
 impl<'a> DenyHeader<'a> {
+    /// Returns a reference to the name of the header associated with the
+    /// predicate error.
     pub fn name(&self) -> &'a HeaderName {
         match *self {
             Self::Predicate(name) | Self::Missing(name) => name,

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -23,10 +23,12 @@ pub struct Wildcard;
 
 /// An inexpensive comparison operation that can fail with context.
 pub trait Predicate<Input: ?Sized> {
+    /// The error type returned if the predicate fails.
     type Error<'a>
     where
         Self: 'a;
 
+    /// Compares `self` against `input`.
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>>;
 }
 


### PR DESCRIPTION
Writes documentation for the public members in the guard module that are missing docs.