### PR TITLE
refactor(examples/files): cleanup file server example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
-fs = ["via/file"]
+file = ["via/file"]
 
 aws-lc-rs = ["via/aws-lc-rs"]
 ring = ["via/ring"]
@@ -16,6 +16,10 @@ rustls-23 = ["via/rustls-23"]
 
 tokio-tungstenite = ["via/tokio-tungstenite"]
 tokio-websockets = ["via/tokio-websockets"]
+
+# Internal
+
+__test = ["file", "ring", "tokio-tungstenite"]
 
 [[example]]
 name = "cookies"

--- a/examples/README.md
+++ b/examples/README.md
@@ -123,7 +123,7 @@ A simple file server with hardcoded mime type resolution.
 ### Running the Example
 
 ```sh
-cargo run --example files --features="fs"
+cargo run --example files --features="file"
 ```
 
 Visit http://localhost:8080/ in your browser to see a nostalgic web page with

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -1,12 +1,13 @@
+#![cfg(feature = "fs")]
+
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::{env, thread};
 use tokio::sync::Semaphore;
-use via::{Error, Server};
-
-#[cfg(feature = "fs")]
-use via::{Next, Request, ResultExt};
+use via::response::File;
+use via::{Error, Next, Request, ResultExt, Server};
 
 /// The maximum number of connections we are willing to accept before
 /// accounting for resources other than TCP connections.
@@ -47,21 +48,18 @@ fn resolve_public_dir() -> PathBuf {
     }
 }
 
-#[cfg(feature = "fs")]
 async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
-    use std::ffi::OsStr;
-    use via::response::File;
-
     let semaphore = request.app().semaphore.clone();
     let permit = semaphore.acquire_owned().await?;
 
     let mut path = {
+        let public_dir = request.app().public_dir.as_ref();
         let path_param = request
             .param("path")
             .into_result()
             .unwrap_or("index.html".into());
 
-        request.app().public_dir.join(path_param.as_ref())
+        public_dir.join(path_param.as_ref())
     };
 
     let mime_type = if let Some(ext) = path.extension().and_then(OsStr::to_str) {
@@ -99,10 +97,6 @@ async fn main() -> Result<ExitCode, Error> {
     };
 
     let public_dir = resolve_public_dir();
-
-    if cfg!(not(feature = "fs")) {
-        panic!("the \"fs\" feature must be enabled in order to serve files.");
-    }
 
     if cfg!(debug_assertions) {
         println!("serving files from: {:?}", &public_dir);

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -14,6 +14,7 @@ const MAX_CONNECTIONS: usize = 1024;
 /// This is used to provide padding for the runtime so we can deterministically
 /// calculate the number of file descriptors required for the server to never
 /// trigger an EMFILE.
+#[cfg(unix)]
 const RT_FD_REQUIREMENT: usize = 13;
 
 #[cfg_attr(not(feature = "file"), allow(dead_code))]

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -1,15 +1,7 @@
-#[cfg(not(feature = "file"))]
-compile_error!(concat!(
-    "the \"file\" feature must be enabled to run this example.\n",
-    "re-run this example with: cargo run --example files --features=\"file\""
-));
-
-use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
-use via::response::File;
 use via::{Error, Next, Request, Server};
 
 /// The maximum number of connections we are willing to accept before
@@ -24,6 +16,7 @@ const MAX_CONNECTIONS: usize = 1024;
 /// trigger an EMFILE.
 const RT_FD_REQUIREMENT: usize = 13;
 
+#[cfg_attr(not(feature = "file"), allow(dead_code))]
 struct Unicorn {
     /// The directory from which files can be served.
     public_dir: Box<Path>,
@@ -33,6 +26,7 @@ struct Unicorn {
     semaphore: Arc<Semaphore>,
 }
 
+#[cfg_attr(not(feature = "file"), allow(dead_code))]
 impl Unicorn {
     fn public_dir(&self) -> &Path {
         &self.public_dir
@@ -65,6 +59,7 @@ fn determine_resource_usage() -> via::Result<(usize, usize)> {
 }
 
 /// Extracts the relative path to the requested file from the request.
+#[cfg(feature = "file")]
 fn extract_file_path(request: &Request<Unicorn>) -> via::Result<PathBuf> {
     let public_dir = request.app().public_dir();
 
@@ -86,7 +81,11 @@ fn resolve_public_dir() -> PathBuf {
     }
 }
 
+#[cfg(feature = "file")]
 async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
+    use std::ffi::OsStr;
+    use via::response::File;
+
     let permit = request.app().semaphore().clone().acquire_owned().await?;
     let mut path = extract_file_path(&request)?;
     let content_type = if let Some(extension) = path.extension().and_then(OsStr::to_str) {
@@ -104,6 +103,11 @@ async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
         .await
 }
 
+#[cfg(not(feature = "file"))]
+async fn serve_dir(_: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
+    panic!("");
+}
+
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
     let (max_open_files, max_connections) = determine_resource_usage()?;
@@ -113,6 +117,12 @@ async fn main() -> Result<ExitCode, Error> {
     });
 
     app.route("/*path").to(via::get(serve_dir));
+
+    if cfg!(not(feature = "file")) {
+        eprintln!("    the \"file\" feature flag is required in order to run the files example.");
+        eprintln!("    re-run this example with cargo run --example files --feature=\"file\"");
+        return Ok(ExitCode::FAILURE);
+    }
 
     Server::new(app)
         .max_connections(max_connections)

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -1,21 +1,26 @@
-use std::env;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
+use std::{env, thread};
 use tokio::sync::Semaphore;
-use via::{Error, Middleware, Next, Request, Server};
+use via::{Error, Next, Request, ResultExt, Server};
 
-const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
+/// The maximum number of connections we are willing to accept before
+/// accounting for resources other than TCP connections.
+const MAX_CONNECTIONS: usize = 1024;
 
-const MAX_CONNECTIONS: usize = 1000;
-
-#[cfg(feature = "fs")]
-const MAX_ALLOC_SIZE: u64 = 1024 * 1024; // 1 MB
+/// The number of file descriptors required for the multi-threaded tokio
+/// runtime, a graceful shutdown signal, and a tcp listener.
+///
+/// This is used to provide padding for the runtime so we can deterministically
+/// calculate the number of file descriptors required for the server to never
+/// trigger an EMFILE.
+const RT_FD_REQUIREMENT: usize = 13;
 
 #[allow(dead_code)]
-struct ServeFrom {
+struct Unicorn {
     /// The directory from which files can be served.
-    public_dir: PathBuf,
+    public_dir: Arc<Path>,
 
     /// Limit concurrent requests to prevent exit on EMFILE (for safety).
     /// Via prefers that fd back-pressure be a user-space responsibility.
@@ -29,6 +34,8 @@ struct ServeFrom {
 /// compiled. Then,
 ///
 fn resolve_public_dir() -> PathBuf {
+    const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
+
     let manifest_dir = Path::new(CARGO_MANIFEST_DIR);
 
     if CARGO_MANIFEST_DIR.ends_with("examples") {
@@ -38,65 +45,43 @@ fn resolve_public_dir() -> PathBuf {
     }
 }
 
-impl ServeFrom {
-    fn new(concurrency: usize, public_dir: impl AsRef<Path>) -> Self {
-        Self {
-            public_dir: public_dir.as_ref().to_path_buf(),
-            semaphore: Arc::new(Semaphore::new(concurrency)),
-        }
-    }
-}
-
-#[cfg(not(feature = "fs"))]
-impl<T: Send + Sync> Middleware<T> for ServeFrom {
-    fn call(&self, _: Request<T>, _: Next<T>) -> via::BoxFuture {
-        unreachable!()
-    }
-}
-
 #[cfg(feature = "fs")]
-impl<T: Send + Sync> Middleware<T> for ServeFrom {
-    fn call(&self, request: Request<T>, _: Next<T>) -> via::BoxFuture {
-        use std::ffi::OsStr;
-        use via::response::File;
+async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
+    use std::ffi::OsStr;
+    use via::response::File;
 
-        let semaphore = self.semaphore.clone();
-        let mut path = match request.param("path").ok() {
-            Err(error) => return Box::pin(async { Err(error) }),
-            Ok(option) => self
-                .public_dir
-                .join(option.as_deref().unwrap_or("index.html")),
-        };
+    let semaphore = request.app().semaphore.clone();
+    let permit = semaphore.acquire_owned().await?;
 
-        Box::pin(async move {
-            let permit = semaphore.acquire_owned().await?;
+    let mut path = {
+        let path_param = request
+            .param("path")
+            .into_result()
+            .unwrap_or("index.html".into());
 
-            let mime_type = if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-                mime_guess::from_ext(ext).first_or_octet_stream()
-            } else {
-                path.set_extension("html");
-                mime_guess::mime::TEXT_HTML_UTF_8
-            };
+        request.app().public_dir.join(path_param.as_ref())
+    };
 
-            let response = File::open(path)
-                .content_type(&mime_type)
-                .with_last_modified()
-                .permit(permit)
-                .serve(MAX_ALLOC_SIZE) // stream files > 1 MB
-                .await?;
+    let mime_type = if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+        mime_guess::from_ext(ext).first_or_octet_stream()
+    } else {
+        path.set_extension("html");
+        mime_guess::mime::TEXT_HTML_UTF_8
+    };
 
-            Ok(response)
-        })
-    }
+    File::open(path)
+        .content_type(&mime_type)
+        .with_last_modified()
+        .permit(permit)
+        .serve(1024 * 1024) // stream files > 1 MB
+        .await
 }
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let mut app = via::app(());
-    let public_dir = resolve_public_dir();
     let (max_concurrency, max_connections) = cfg_select! {
         // On Windows, sockets are not files.
-        windows => (MAX_CONNECTIONS, MAX_CONNECTIONS),
+        windows => (MAX_CONNECTIONS.div_ceil(2), MAX_CONNECTIONS),
 
         // On POSIX, max_concurrency affects the max_connections budget.
         //
@@ -104,20 +89,32 @@ async fn main() -> Result<ExitCode, Error> {
         // amount of concurrent file streams should not exceed the number of
         // worker process in the tokio runtime.
         _ => {{
-            let concurrency = std::thread::available_parallelism()?.get();
-            let adjusted = ((13isize - concurrency as isize) + MAX_CONNECTIONS as isize) as usize;
+            let concurrency = thread::available_parallelism()?.get();
+            let adjusted_max = MAX_CONNECTIONS - RT_FD_REQUIREMENT - concurrency;
 
-            (concurrency, adjusted)
+            (concurrency, adjusted_max)
         }}
     };
+
+    let public_dir = resolve_public_dir();
 
     if cfg!(not(feature = "fs")) {
         panic!("the \"fs\" feature must be enabled in order to serve files.");
     }
 
-    println!("serving files from: {:?}", &public_dir);
+    if cfg!(debug_assertions) {
+        println!("serving files from: {:?}", &public_dir);
+        println!(
+            "  max concurrency = {}, max connections = {}",
+            max_concurrency, max_connections
+        );
+    }
 
-    let serve_dir = ServeFrom::new(max_concurrency, &public_dir);
+    let mut app = via::app(Unicorn {
+        public_dir: public_dir.into(),
+        semaphore: Arc::new(Semaphore::new(max_concurrency)),
+    });
+
     app.route("/*path").to(via::get(serve_dir));
 
     Server::new(app)

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -3,7 +3,10 @@ use std::process::ExitCode;
 use std::sync::Arc;
 use std::{env, thread};
 use tokio::sync::Semaphore;
-use via::{Error, Next, Request, ResultExt, Server};
+use via::{Error, Server};
+
+#[cfg(feature = "fs")]
+use via::{Next, Request, ResultExt};
 
 /// The maximum number of connections we are willing to accept before
 /// accounting for resources other than TCP connections.
@@ -17,7 +20,6 @@ const MAX_CONNECTIONS: usize = 1024;
 /// trigger an EMFILE.
 const RT_FD_REQUIREMENT: usize = 13;
 
-#[allow(dead_code)]
 struct Unicorn {
     /// The directory from which files can be served.
     public_dir: Arc<Path>,

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -1,13 +1,16 @@
-#![cfg(feature = "fs")]
+#[cfg(not(feature = "file"))]
+compile_error!(concat!(
+    "the \"file\" feature must be enabled to run this example.\n",
+    "re-run this example with: cargo run --example files --features=\"file\""
+));
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
-use std::{env, thread};
 use tokio::sync::Semaphore;
 use via::response::File;
-use via::{Error, Next, Request, ResultExt, Server};
+use via::{Error, Next, Request, Server};
 
 /// The maximum number of connections we are willing to accept before
 /// accounting for resources other than TCP connections.
@@ -23,25 +26,60 @@ const RT_FD_REQUIREMENT: usize = 13;
 
 struct Unicorn {
     /// The directory from which files can be served.
-    public_dir: Arc<Path>,
+    public_dir: Box<Path>,
 
     /// Limit concurrent requests to prevent exit on EMFILE (for safety).
     /// Via prefers that fd back-pressure be a user-space responsibility.
     semaphore: Arc<Semaphore>,
 }
 
+impl Unicorn {
+    fn public_dir(&self) -> &Path {
+        &self.public_dir
+    }
+
+    fn semaphore(&self) -> &Arc<Semaphore> {
+        &self.semaphore
+    }
+}
+
+/// Calculates how many files can be open concurrently and returns it along
+/// with the adjusted maximum number of connections.
+fn determine_resource_usage() -> via::Result<(usize, usize)> {
+    cfg_select! {
+        // On Windows, sockets are not files.
+        windows => Ok((MAX_CONNECTIONS.div_ceil(2), MAX_CONNECTIONS)),
+
+        // On POSIX, max_concurrency affects the max_connections budget.
+        //
+        // The default amount of padding provided by Via is 13. The maximum
+        // amount of concurrent file streams should not exceed the number of
+        // worker process in the tokio runtime.
+        _ => {{
+            let concurrency = std::thread::available_parallelism()?.get();
+            let adjusted_max = MAX_CONNECTIONS - RT_FD_REQUIREMENT - concurrency;
+
+            Ok((concurrency, adjusted_max))
+        }}
+    }
+}
+
+/// Extracts the relative path to the requested file from the request.
+fn extract_file_path(request: &Request<Unicorn>) -> via::Result<PathBuf> {
+    let public_dir = request.app().public_dir();
+
+    if let Some(path_param) = request.param("path").ok()?.as_deref() {
+        Ok(public_dir.join(path_param))
+    } else {
+        Ok(public_dir.join("index.html"))
+    }
+}
+
 /// Resolve a relative path to the public directory.
-///
-/// This example can be run from the workspace root or the examples directory.
-/// Therefore, we must determine the context in which this example was
-/// compiled. Then,
-///
 fn resolve_public_dir() -> PathBuf {
-    const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let manifest_dir = Path::new(CARGO_MANIFEST_DIR);
-
-    if CARGO_MANIFEST_DIR.ends_with("examples") {
+    if manifest_dir.ends_with("examples") {
         manifest_dir.join("files/public")
     } else {
         manifest_dir.join("examples/files/public")
@@ -49,28 +87,17 @@ fn resolve_public_dir() -> PathBuf {
 }
 
 async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
-    let semaphore = request.app().semaphore.clone();
-    let permit = semaphore.acquire_owned().await?;
-
-    let mut path = {
-        let public_dir = request.app().public_dir.as_ref();
-        let path_param = request
-            .param("path")
-            .into_result()
-            .unwrap_or("index.html".into());
-
-        public_dir.join(path_param.as_ref())
-    };
-
-    let mime_type = if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-        mime_guess::from_ext(ext).first_or_octet_stream()
+    let permit = request.app().semaphore().clone().acquire_owned().await?;
+    let mut path = extract_file_path(&request)?;
+    let content_type = if let Some(extension) = path.extension().and_then(OsStr::to_str) {
+        mime_guess::from_ext(extension).first_or_octet_stream()
     } else {
         path.set_extension("html");
         mime_guess::mime::TEXT_HTML_UTF_8
     };
 
     File::open(path)
-        .content_type(&mime_type)
+        .content_type(&content_type)
         .with_last_modified()
         .permit(permit)
         .serve(1024 * 1024) // stream files > 1 MB
@@ -79,36 +106,10 @@ async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let (max_concurrency, max_connections) = cfg_select! {
-        // On Windows, sockets are not files.
-        windows => (MAX_CONNECTIONS.div_ceil(2), MAX_CONNECTIONS),
-
-        // On POSIX, max_concurrency affects the max_connections budget.
-        //
-        // The default amount of padding provided by Via is 13. The maximum
-        // amount of concurrent file streams should not exceed the number of
-        // worker process in the tokio runtime.
-        _ => {{
-            let concurrency = thread::available_parallelism()?.get();
-            let adjusted_max = MAX_CONNECTIONS - RT_FD_REQUIREMENT - concurrency;
-
-            (concurrency, adjusted_max)
-        }}
-    };
-
-    let public_dir = resolve_public_dir();
-
-    if cfg!(debug_assertions) {
-        println!("serving files from: {:?}", &public_dir);
-        println!(
-            "  max concurrency = {}, max connections = {}",
-            max_concurrency, max_connections
-        );
-    }
-
+    let (max_open_files, max_connections) = determine_resource_usage()?;
     let mut app = via::app(Unicorn {
-        public_dir: public_dir.into(),
-        semaphore: Arc::new(Semaphore::new(max_concurrency)),
+        public_dir: resolve_public_dir().into_boxed_path(),
+        semaphore: Arc::new(Semaphore::new(max_open_files)),
     });
 
     app.route("/*path").to(via::get(serve_dir));

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -106,7 +106,7 @@ async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
 
 #[cfg(not(feature = "file"))]
 async fn serve_dir(_: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
-    panic!("");
+    panic!("the \"file\" feature flag is required in order to run the files example.");
 }
 
 #[tokio::main]

--- a/via/src/lib.rs
+++ b/via/src/lib.rs
@@ -1,3 +1,5 @@
+// #![deny(missing_docs)]
+
 //! An async multi-threaded web framework for people who appreciate simplicity.
 //!
 //! Documentation is sparse at the moment, but the code is well-commented for


### PR DESCRIPTION
Cleans up the file server example. In theory, these should be identical in functionality. This version is more refined, concise, and explicit about purpose.

The main difference in functionality is that file server state and config is stored in the global application state rather than fields of a middleware struct. Both should be equally safe. Their both obfuscated structs that are heap allocated with a single layer of dynamic dispatch. Not all that different than a boxed future.

This demonstrates our DI API nicely so it's probably a better example.

The math used to determine resource usage ahead of runtime also makes a lot more sense.

This is also helpful example for anyone looking to use additional resources such as a database pool or http client connection pool with Via.

