### PR TITLE
fix(examples/files): remove commented out import

### DIFF
--- a/via/src/response/file.rs
+++ b/via/src/response/file.rs
@@ -11,7 +11,6 @@ use tokio::fs::File as TokioFile;
 use tokio::io::AsyncReadExt;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio_util::io::ReaderStream;
-// use tokio_util::io::poll_read_buf;
 
 use super::{Finalize, Response, ResponseBuilder};
 use crate::{Error, deny};


### PR DESCRIPTION
Removes a dependency that is no longer used that was commented out of the files example.