### PR TITLE
docs(via): specify the exact version in README Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-gm.53"
+via = "=2.0.0-gm.53"
 http = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```


### PR DESCRIPTION
Updates the README to specify the exact version in Cargo.toml. This fixes a bug that prevents users from using the exact version that they specify. This is a temporary fix until the official 2.0 release is cut.