### PR TITLE
feat(via): support coalesce on RequestBody

### DIFF
--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -505,6 +505,15 @@ impl Future for WithTrailers {
 }
 
 impl RequestBody {
+    /// Aggregate the frames of the request body into a contiguous block of
+    /// memory.
+    #[inline]
+    pub fn coalesce(self) -> Coalesce {
+        Coalesce { body: self }
+    }
+}
+
+impl RequestBody {
     pub(crate) fn new(remaining: usize, body: Incoming, frames: Vec<Bytes>) -> Self {
         Self {
             remaining,


### PR DESCRIPTION
Provides the ability to coalesce a `RequestBody` when working specifically with the `RequestBody`. Previously, it was required to use either [`http-body-util`](https://crates.io/crates/http-body-util) or `Request::into_future` in order to read the entire contents of the request body into memory.