### PR TITLE
refactor(via): guard::guard ~> guard::barrier

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::process::ExitCode;
-use via::guard::{content, header::media};
-use via::{Next, Payload, Request, Response, Server, guard, rescue};
+use via::guard::{self, content, header::media};
+use via::{Next, Payload, Request, Response, Server, rescue};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Document<T> {
@@ -41,7 +41,7 @@ async fn main() -> via::Result<ExitCode> {
     app.middleware(rescue(|error| error.use_json()));
 
     // If the client does not speak JSON, deny the request.
-    app.middleware(guard(content(media::json(), media::json())));
+    app.middleware(guard::barrier(content(media::json(), media::json())));
 
     // Define a route that responds to POST /hello.
     app.route("/hello").to(via::post(hello).or_deny());

--- a/via/src/guard/method.rs
+++ b/via/src/guard/method.rs
@@ -17,7 +17,7 @@
 //! The predicates in this module are not routing primitives.
 //!
 //! A method predicate classifies a request by method. When used with
-//! [`guard`], [`filter`], or [`flat_map`], it acts as stateless higher-order
+//! [`barrier`], [`filter`], or [`flat_map`], it acts as stateless higher-order
 //! middleware that decides whether the remaining subtree should be entered,
 //! skipped, or denied.
 //!
@@ -60,10 +60,10 @@
 //! [`Method`]: http::Method
 //! [`Request`]: crate::Request
 //! [`Switch`]: crate::router::Switch
+//! [`barrier`]: crate::guard::barrier
 //! [`filter`]: crate::guard::filter
 //! [`flat_map`]: crate::guard::flat_map
 //! [`get`]: crate::get
-//! [`guard`]: crate::guard::guard
 //! [`on`]: crate::guard::on
 //! [`post`]: crate::post
 //! [`put`]: crate::put

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -51,24 +51,6 @@ pub struct FlatMap<T, U> {
     middleware: U,
 }
 
-/// Call `middleware` if `predicate` matches the request.
-pub fn filter<T, U>(predicate: T, middleware: U) -> Filter<T, U> {
-    Filter {
-        predicate,
-        middleware,
-    }
-}
-
-/// Confirm that the request matches `predicate` before calling `middleware`.
-///
-/// Unlike [`guard`], the provided predicate only applies to `middleware`.
-pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
-    FlatMap {
-        predicate,
-        middleware,
-    }
-}
-
 /// Deny the request if it does not match `predicate`.
 ///
 /// The `guard` fn is preferred when you want every request to a subtree of
@@ -77,14 +59,13 @@ pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
 /// # Example
 ///
 /// ```rust
-/// use via::guard::{content, header::media};
-/// use via::guard;
+/// use via::guard::{self, content, header::media};
 ///
 /// let mut app = via::app(());
 /// let mut api = app.route("/api");
 ///
 /// // If the client does not speak JSON, deny the request.
-/// api.middleware(guard(content(media::json(), media::json())));
+/// api.middleware(guard::barrier(content(media::json(), media::json())));
 ///
 /// // Subsequent routes defined from `api` require:
 /// //   - Accept: application/json, */*
@@ -95,8 +76,28 @@ pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
 ///     // Define the /api/users resource.
 /// });
 /// ```
-pub fn guard<T>(predicate: T) -> FlatMap<T, Continue> {
+pub fn barrier<T>(predicate: T) -> FlatMap<T, Continue> {
     flat_map(predicate, Continue)
+}
+
+/// Call `middleware` if `predicate` matches the request.
+///
+/// Unlike [`barrier`], the predicate provided only applies to `middleware`.
+pub fn filter<T, U>(predicate: T, middleware: U) -> Filter<T, U> {
+    Filter {
+        predicate,
+        middleware,
+    }
+}
+
+/// Confirm that the request matches `predicate` before calling `middleware`.
+///
+/// Unlike [`barrier`], the predicate provided only applies to `middleware`.
+pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
+    FlatMap {
+        predicate,
+        middleware,
+    }
 }
 
 /// Require that the header associated with `key` matches `predicate`.

--- a/via/src/lib.rs
+++ b/via/src/lib.rs
@@ -65,7 +65,6 @@ mod util;
 pub use app::{Shared, Via, app};
 pub use cookies::{Cookies, cookies};
 pub use error::{Error, ResultExt, rescue};
-pub use guard::guard;
 pub use middleware::{BoxFuture, Middleware, Result, middleware};
 pub use next::{Continue, Next};
 pub use request::{Payload, Request};


### PR DESCRIPTION
Renames `via::guard::guard` to `via::guard::barrier` as it is more descriptive of the guard's behavior. A `barrier` applies to the entire subtree of remaining middleware. A `flat_map` or `filter` apply to an individual middleware.