### PR TITLE
docs(via): document the map_err predicate

### DIFF
--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -320,12 +320,14 @@ macro_rules! impl_or_predicate {
 /// ```
 /// use http::Version;
 /// use via::guard::{self, map_err};
-/// #
-/// # let mut app = via::app(());
+/// use via::{err, Request};
+///
+/// // Create a new application.
+/// let mut app = via::app(());
 ///
 /// // Only support request made with HTTP versions >= 1.1.
 /// app.middleware(guard::barrier(map_err(
-///     |_| via::err!(400, "http version not supported"),
+///     |_| err!(400, "http version not supported"),
 ///     |request: &Request| request.version() > Version::HTTP_10,
 /// )));
 /// ```

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -310,7 +310,25 @@ macro_rules! impl_or_predicate {
 
 /// Map the provided predicate's error to a different type.
 ///
-/// The returned error type must erase the lifetime of the original error.
+/// The returned error type must erase the lifetime of the original error. This
+/// combinator is particularlly useful when using a closure as a top-level
+/// predicate that must return an `Error` type that can be converted to a
+/// [`via::Error`](crate::Error).
+///
+/// # Example
+///
+/// ```
+/// use http::Version;
+/// use via::guard::{self, map_err};
+/// #
+/// # let mut app = via::app(());
+///
+/// // Only support request made with HTTP versions >= 1.1.
+/// app.middleware(guard::barrier(map_err(
+///     |_| via::err!(400, "http version not supported"),
+///     |request: &Request| request.version() > Version::HTTP_10,
+/// )));
+/// ```
 pub fn map_err<F, T>(f: F, predicate: T) -> MapErr<F, T> {
     MapErr(f, predicate)
 }


### PR DESCRIPTION
Documents the `map_err` predicate. The example also answers the question: "how can I use a closure as a top-level predicate" for a guard.