### PR TITLE
refactor(via): predicate first in guard::map_err

### DIFF
--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -4,7 +4,7 @@ use std::convert::Infallible;
 pub struct And<T>(T);
 
 /// Map a predicate's error to a different type.
-pub struct MapErr<F, T>(F, T);
+pub struct MapErr<T, F>(T, F);
 
 /// Coerce a predicate to a boolean expression and negate it.
 pub struct Not<T>(T);
@@ -327,12 +327,12 @@ macro_rules! impl_or_predicate {
 ///
 /// // Only support request made with HTTP versions >= 1.1.
 /// app.middleware(guard::barrier(map_err(
-///     |_| err!(400, "http version not supported"),
 ///     |request: &Request| request.version() > Version::HTTP_10,
+///     |_| err!(400, "http version not supported"),
 /// )));
 /// ```
-pub fn map_err<F, T>(f: F, predicate: T) -> MapErr<F, T> {
-    MapErr(f, predicate)
+pub fn map_err<T, F>(predicate: T, map: F) -> MapErr<T, F> {
+    MapErr(predicate, map)
 }
 
 /// Coerce `predicate` to a boolean expression and negate it.

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -372,16 +372,16 @@ pub fn wildcard() -> Wildcard {
 and_impls!(A B C D E F G H I J);
 or_impls!(A B C D E F G H I J);
 
-impl<E, F, T, Input> Predicate<Input> for MapErr<F, T>
+impl<T, E, F, Input> Predicate<Input> for MapErr<T, F>
 where
-    for<'a> F: Fn(T::Error<'_>) -> E + Copy + 'a,
     for<'a> T: Predicate<Input> + 'a,
+    for<'a> F: Fn(T::Error<'_>) -> E + Copy + 'a,
     Input: ?Sized,
 {
     type Error<'a> = E;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
-        self.1.cmp(input).map_err(&self.0)
+        self.0.cmp(input).map_err(&self.1)
     }
 }
 


### PR DESCRIPTION
Refactors `guard::map_err` to take `predicate` as the first argument for consistency with all other predicate combinators.