### PR TITLE
refactor(via): clean guard module exports + combinator improvements

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::process::ExitCode;
-use via::guard::{self, header::media};
+use via::guard::{self, media};
 use via::{Next, Payload, Request, Response, Server, rescue};
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -41,7 +41,7 @@ async fn main() -> via::Result<ExitCode> {
     app.middleware(rescue(|error| error.use_json()));
 
     // If the client does not speak JSON, deny the request.
-    app.middleware(guard::barrier(guard::content!(media::json)));
+    app.middleware(guard::barrier(guard::content!(media::json())));
 
     // Define a route that responds to POST /hello.
     app.route("/hello").to(via::post(hello).or_deny());

--- a/via-macros/Cargo.toml
+++ b/via-macros/Cargo.toml
@@ -8,4 +8,5 @@ description = "A fast and flexible http router."
 homepage = "https://github.com/via-rs/via"
 repository = "https://github.com/via-rs/via"
 
-[dependencies]
+[dev-dependencies]
+via = { path = "../via" }

--- a/via-macros/src/guard.rs
+++ b/via-macros/src/guard.rs
@@ -13,7 +13,7 @@ macro_rules! content {
                 via::guard::header::content_type($accepts()),
                 via::guard::header::content_length(),
             )),
-            via::guard::header::accept($provides()),
+            via::guard::on::headers(via::guard::header::accept($provides())),
         )
     };
     ($accepts:expr) => {

--- a/via-macros/src/guard.rs
+++ b/via-macros/src/guard.rs
@@ -6,17 +6,15 @@
 #[macro_export]
 macro_rules! content {
     ($accepts:expr, $provides:expr) => {
-        via::guard::or((
-            via::guard::when(
-                via::guard::method::is_mutation(),
-                via::guard::on::headers((
-                    via::guard::header::accept($provides()),
-                    via::guard::header::content_type($accepts()),
-                    via::guard::header::content_length(),
-                )),
-            ),
+        via::guard::if_else(
+            via::guard::method::is_mutation(),
+            via::guard::on::headers((
+                via::guard::header::accept($provides()),
+                via::guard::header::content_type($accepts()),
+                via::guard::header::content_length(),
+            )),
             via::guard::header::accept($provides()),
-        ))
+        )
     };
     ($accepts:expr) => {
         $crate::content!($accepts, $accepts)

--- a/via-macros/src/guard.rs
+++ b/via-macros/src/guard.rs
@@ -1,19 +1,55 @@
-/// The client and server agree on a media type and payloads have a known
-/// length.
+/// Negotiate request and response media types.
 ///
-/// The first argument is what the client is allowed to send. The second
-/// argument is how the server will reply.
+/// `content!` builds a predicate that validates the request's content
+/// contract before body parsing or response generation occurs.
+///
+/// The first argument describes what the client is allowed to send. The second
+/// argument describes what the server will send in response.
+///
+/// ```
+/// # use via::guard::{self, media};
+/// let predicate = guard::content!(media::json(), media::json());
+/// ```
+///
+/// If both sides use the same media predicate, pass a single argument:
+///
+/// ```
+/// # use via::guard::{self, media};
+/// let predicate = guard::content!(media::json());
+/// ```
+///
+/// For safe requests, only the `Accept` header is checked. Safe requests do
+/// not carry a required request payload, so `Content-Type` and
+/// `Content-Length` are not required.
+///
+/// For mutation requests, `content!` checks all of the following:
+///
+/// - `Accept` must include the response media type provided by the server.
+/// - `Content-Type` must match the request media type accepted by the server.
+/// - `Content-Length` must be present.
+///
+/// This makes `content!` useful as a subtree `barrier`. If a request cannot
+/// exchange the expected media type, downstream middleware such as session
+/// restoration, body aggregation, and deserialization can be skipped.
+///
+/// # Example
+///
+/// ```
+/// # use via::guard::{self, media};
+/// # let mut app = via::app(());
+/// app.middleware(guard::barrier(guard::content!(media::json())));
+/// ```
 #[macro_export]
 macro_rules! content {
     ($accepts:expr, $provides:expr) => {
         via::guard::if_else(
             via::guard::method::is_mutation(),
             via::guard::on::headers((
-                via::guard::header::accept($provides()),
-                via::guard::header::content_type($accepts()),
+                via::guard::header::accept($provides),
+                via::guard::header::content_type($accepts),
                 via::guard::header::content_length(),
             )),
-            via::guard::on::headers(via::guard::header::accept($provides())),
+            via::guard::on::headers(via::guard::header::accept($provides)),
         )
     };
     ($accepts:expr) => {

--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1"
 smallvec = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tokio-websockets = { version = "0.13", features = ["ring", "server"], optional = true }
-via-macros = { path = "../via-macros" }
+via-macros = { path = "../via-macros", version = "0.1" }
 via-router = { version = "3.0.0-beta.34" }
 zeroize = "1"
 

--- a/via/src/guard/bytes.rs
+++ b/via/src/guard/bytes.rs
@@ -40,6 +40,11 @@ macro_rules! cmp_bytes {
 }
 
 cmp_bytes! {
+    #[doc = "The input is equal to `predicate`."]
+    pub fn case_sensitive(self: &CaseSensitive, predicate: &[u8]) -> bool {
+        self.0.as_slice() == predicate
+    }
+
     #[doc = "The input is equal to or ends with `suffix`."]
     pub fn ends_with(self: &EndsWith, suffix: &[u8]) -> bool {
         suffix.ends_with(self.0.as_slice())
@@ -48,11 +53,6 @@ cmp_bytes! {
     #[doc = "The input is equal to or starts with `prefix`."]
     pub fn starts_with(self: &StartsWith, prefix: &[u8]) -> bool {
         prefix.starts_with(self.0.as_slice())
-    }
-
-    #[doc = "The input is equal to `predicate`."]
-    pub fn tag_no_case(self: &TagNoCase, predicate: &[u8]) -> bool {
-        self.0.as_slice() == predicate
     }
 
     #[doc = "The input is a case-insensitive match for `predicate`."]

--- a/via/src/guard/bytes.rs
+++ b/via/src/guard/bytes.rs
@@ -8,6 +8,11 @@ pub struct Contains<T = Tag> {
     separator: u8,
 }
 
+/// Trim the ASCII whitespace around the input before testing a predicate.
+pub struct Trim<T> {
+    predicate: T,
+}
+
 macro_rules! cmp_bytes {
     ($(
         $(#[$($doc:tt)*])?
@@ -70,6 +75,22 @@ pub fn contains<T>(predicate: T, separator: u8) -> Contains<T> {
     }
 }
 
+/// Trim the ASCII whitespace around the input before testing `predicate`.
+pub fn trim<T>(predicate: T) -> Trim<T> {
+    Trim { predicate }
+}
+
+impl<T> Predicate<[u8]> for Trim<T>
+where
+    for<'a> T: Predicate<[u8]> + 'a,
+{
+    type Error<'a> = T::Error<'a>;
+
+    fn cmp<'a>(&'a self, input: &[u8]) -> Result<(), Self::Error<'a>> {
+        self.predicate.cmp(input.trim_ascii())
+    }
+}
+
 impl<T> Predicate<[u8]> for Contains<T>
 where
     for<'a> T: Predicate<[u8]> + 'a,
@@ -77,10 +98,12 @@ where
     type Error<'a> = ();
 
     fn cmp<'a>(&'a self, value: &[u8]) -> Result<(), Self::Error<'a>> {
-        if value.split(|byte| byte == &self.separator).any(|item| {
-            let input = item.trim_ascii();
-            self.predicate.cmp(input).is_ok()
-        }) {
+        let separator = &self.separator;
+
+        if value
+            .split(|byte| byte == separator)
+            .any(|input| self.predicate.cmp(input).is_ok())
+        {
             Ok(())
         } else {
             Err(())

--- a/via/src/guard/bytes.rs
+++ b/via/src/guard/bytes.rs
@@ -40,9 +40,9 @@ macro_rules! cmp_bytes {
 }
 
 cmp_bytes! {
-    #[doc = "The input is equal to `predicate`."]
-    pub fn case_sensitive(self: &CaseSensitive, predicate: &[u8]) -> bool {
-        self.0.as_slice() == predicate
+    #[doc = "The input is equal to or ends with `suffix`."]
+    pub fn ends_with(self: &EndsWith, suffix: &[u8]) -> bool {
+        suffix.ends_with(self.0.as_slice())
     }
 
     #[doc = "The input is equal to or starts with `prefix`."]
@@ -50,9 +50,9 @@ cmp_bytes! {
         prefix.starts_with(self.0.as_slice())
     }
 
-    #[doc = "The input is equal to or ends with `suffix`."]
-    pub fn ends_with(self: &EndsWith, suffix: &[u8]) -> bool {
-        suffix.ends_with(self.0.as_slice())
+    #[doc = "The input is equal to `predicate`."]
+    pub fn tag_no_case(self: &TagNoCase, predicate: &[u8]) -> bool {
+        self.0.as_slice() == predicate
     }
 
     #[doc = "The input is a case-insensitive match for `predicate`."]

--- a/via/src/guard/bytes.rs
+++ b/via/src/guard/bytes.rs
@@ -98,10 +98,8 @@ where
     type Error<'a> = ();
 
     fn cmp<'a>(&'a self, value: &[u8]) -> Result<(), Self::Error<'a>> {
-        let separator = &self.separator;
-
         if value
-            .split(|byte| byte == separator)
+            .split(|byte| *byte == self.separator)
             .any(|input| self.predicate.cmp(input).is_ok())
         {
             Ok(())

--- a/via/src/guard/bytes.rs
+++ b/via/src/guard/bytes.rs
@@ -1,7 +1,12 @@
+//! Byte-level predicates for matching header values and URI components.
+
 use super::Predicate;
 
 /// Match a predicate against a comma separated value in the input.
-pub struct Contains<T = Tag>(T);
+pub struct Contains<T = Tag> {
+    predicate: T,
+    separator: u8,
+}
 
 macro_rules! cmp_bytes {
     ($(
@@ -51,9 +56,18 @@ cmp_bytes! {
     }
 }
 
-/// Match `predicate` against a comma separated value in the input.
-pub fn contains<T>(predicate: T) -> Contains<T> {
-    Contains(predicate)
+/// The `predicate` must match an item in the input separated by `separator`.
+///
+/// Contains is a short-circuiting predicate that terminates as soon as a
+/// matching item is found.
+///
+/// ASCII whitespace around each input is trimmed before it is tested against
+/// `predicate`.
+pub fn contains<T>(predicate: T, separator: u8) -> Contains<T> {
+    Contains {
+        predicate,
+        separator,
+    }
 }
 
 impl<T> Predicate<[u8]> for Contains<T>
@@ -63,10 +77,10 @@ where
     type Error<'a> = ();
 
     fn cmp<'a>(&'a self, value: &[u8]) -> Result<(), Self::Error<'a>> {
-        if value
-            .split(|b| *b == b',')
-            .any(|item| self.0.cmp(item.trim_ascii()).is_ok())
-        {
+        if value.split(|byte| byte == &self.separator).any(|item| {
+            let input = item.trim_ascii();
+            self.predicate.cmp(input).is_ok()
+        }) {
             Ok(())
         } else {
             Err(())

--- a/via/src/guard/error.rs
+++ b/via/src/guard/error.rs
@@ -7,6 +7,9 @@ use crate::{Error, err};
 /// The request URI query is required.
 pub struct MissingUriQuery;
 
+/// The request is missing an extension.
+pub struct UnknownExtension;
+
 pub struct InvalidHeader<'a> {
     source: OnError<&'a HeaderName, &'a HeaderName>,
 }
@@ -126,5 +129,11 @@ impl From<InvalidHeader<'_>> for Error {
                 }
             },
         }
+    }
+}
+
+impl From<UnknownExtension> for Error {
+    fn from(_: UnknownExtension) -> Self {
+        err!(500, "unknown request extension.")
     }
 }

--- a/via/src/guard/error.rs
+++ b/via/src/guard/error.rs
@@ -1,15 +1,19 @@
 //! Contextual errors and error helper types.
 
-use http::Method;
+use http::{HeaderName, Method};
 
 use crate::{Error, err};
 
-/// The request URI query is empty or None.
-pub struct EmptyQuery;
+/// The request URI query is required.
+pub struct MissingUriQuery;
+
+pub struct InvalidHeader<'a> {
+    source: OnError<&'a HeaderName, &'a HeaderName>,
+}
 
 /// The error type returned by the [`map_err`](super::map_err) predicate.
 pub struct MapError<'a, F, E> {
-    convert: &'a F,
+    op: &'a F,
     error: E,
 }
 
@@ -20,20 +24,14 @@ pub struct MethodNotAllowed<'a> {
 
 /// An error originating from a field projection or predicate.
 #[derive(Debug)]
-pub struct OnError<T, U> {
-    pub(super) kind: OnErrorKind<T, U>,
-}
-
-/// Represents a field projection or predicate that failed.
-#[derive(Debug)]
-pub(super) enum OnErrorKind<T, U> {
+pub enum OnError<T, U> {
     Predicate(T),
     Project(U),
 }
 
 impl<'a, F, E> MapError<'a, F, E> {
-    pub(super) fn new(convert: &'a F, error: E) -> Self {
-        Self { convert, error }
+    pub(super) fn new(op: &'a F, error: E) -> Self {
+        Self { op, error }
     }
 }
 
@@ -42,7 +40,7 @@ where
     F: Fn(E) -> Error,
 {
     fn from(into: MapError<'_, F, E>) -> Self {
-        (into.convert)(into.error)
+        (into.op)(into.error)
     }
 }
 
@@ -58,34 +56,75 @@ impl From<MethodNotAllowed<'_>> for Error {
     }
 }
 
-impl<T, U> OnError<T, U> {
-    pub(super) fn predicate(error: T) -> Self {
-        Self {
-            kind: OnErrorKind::Predicate(error),
-        }
-    }
-
-    pub(super) fn project(error: U) -> Self {
-        Self {
-            kind: OnErrorKind::Project(error),
-        }
-    }
-}
-
 impl<T, U> From<OnError<T, U>> for Error
 where
     Error: From<T> + From<U>,
 {
     fn from(error: OnError<T, U>) -> Self {
-        match error.kind {
-            OnErrorKind::Predicate(error) => error.into(),
-            OnErrorKind::Project(error) => error.into(),
+        match error {
+            OnError::Predicate(error) => error.into(),
+            OnError::Project(error) => error.into(),
         }
     }
 }
 
-impl From<EmptyQuery> for Error {
-    fn from(_: EmptyQuery) -> Self {
+impl From<MissingUriQuery> for Error {
+    fn from(_: MissingUriQuery) -> Self {
         err!(400, "request uri query cannot be empty.")
+    }
+}
+
+impl<'a> InvalidHeader<'a> {
+    pub(super) fn new(source: OnError<&'a HeaderName, &'a HeaderName>) -> Self {
+        Self { source }
+    }
+
+    pub fn name(&self) -> &HeaderName {
+        match self.source {
+            OnError::Predicate(name) | OnError::Project(name) => name,
+        }
+    }
+}
+
+impl From<InvalidHeader<'_>> for Error {
+    fn from(error: InvalidHeader<'_>) -> Self {
+        match error.source {
+            // The header was present but the predicate failed.
+            OnError::Predicate(name) => match name.as_str() {
+                "accept" => {
+                    err!(406, "response media type not supported.")
+                }
+                "authorization" => {
+                    err!(401, "unauthorized.")
+                }
+                "content-type" => {
+                    err!(415, "request media type not supported.")
+                }
+                "range" => {
+                    err!(416, "unsatisfiable range request.")
+                }
+                "upgrade" => {
+                    err!(426, "protocol upgrade is not supported.")
+                }
+                name => {
+                    err!(400, "invalid header value: {}.", name)
+                }
+            },
+            // The header is required but was not present in the request.
+            OnError::Project(project) => match project.as_str() {
+                "content-length" => {
+                    err!(411, "length required.")
+                }
+                name @ ("if-match"
+                | "if-none-match"
+                | "if-modified-since"
+                | "if-unmodified-since") => {
+                    err!(428, "missing required precondition: {}.", name)
+                }
+                name => {
+                    err!(400, "missing required header: {}.", name)
+                }
+            },
+        }
     }
 }

--- a/via/src/guard/error.rs
+++ b/via/src/guard/error.rs
@@ -10,6 +10,7 @@ pub struct MissingUriQuery;
 /// The request is missing an extension.
 pub struct UnknownExtension;
 
+/// A request header is either missing or invalid.
 pub struct InvalidHeader<'a> {
     source: OnError<&'a HeaderName, &'a HeaderName>,
 }
@@ -82,7 +83,7 @@ impl<'a> InvalidHeader<'a> {
         Self { source }
     }
 
-    pub fn name(&self) -> &HeaderName {
+    pub(crate) fn name(&self) -> &HeaderName {
         match self.source {
             OnError::Predicate(name) | OnError::Project(name) => name,
         }

--- a/via/src/guard/error.rs
+++ b/via/src/guard/error.rs
@@ -83,6 +83,7 @@ impl<'a> InvalidHeader<'a> {
         Self { source }
     }
 
+    #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
     pub(crate) fn name(&self) -> &HeaderName {
         match self.source {
             OnError::Predicate(name) | OnError::Project(name) => name,

--- a/via/src/guard/error.rs
+++ b/via/src/guard/error.rs
@@ -1,0 +1,91 @@
+//! Contextual errors and error helper types.
+
+use http::Method;
+
+use crate::{Error, err};
+
+/// The request URI query is empty or None.
+pub struct EmptyQuery;
+
+/// The error type returned by the [`map_err`](super::map_err) predicate.
+pub struct MapError<'a, F, E> {
+    convert: &'a F,
+    error: E,
+}
+
+/// A contextual, `405 Method Not Allowed` error.
+pub struct MethodNotAllowed<'a> {
+    allow: &'a Method,
+}
+
+/// An error originating from a field projection or predicate.
+#[derive(Debug)]
+pub struct OnError<T, U> {
+    pub(super) kind: OnErrorKind<T, U>,
+}
+
+/// Represents a field projection or predicate that failed.
+#[derive(Debug)]
+pub(super) enum OnErrorKind<T, U> {
+    Predicate(T),
+    Project(U),
+}
+
+impl<'a, F, E> MapError<'a, F, E> {
+    pub(super) fn new(convert: &'a F, error: E) -> Self {
+        Self { convert, error }
+    }
+}
+
+impl<F, E> From<MapError<'_, F, E>> for Error
+where
+    F: Fn(E) -> Error,
+{
+    fn from(into: MapError<'_, F, E>) -> Self {
+        (into.convert)(into.error)
+    }
+}
+
+impl<'a> MethodNotAllowed<'a> {
+    pub(super) fn new(allow: &'a Method) -> Self {
+        Self { allow }
+    }
+}
+
+impl From<MethodNotAllowed<'_>> for Error {
+    fn from(error: MethodNotAllowed<'_>) -> Self {
+        err!(405, "expected request method to be {}", &error.allow)
+    }
+}
+
+impl<T, U> OnError<T, U> {
+    pub(super) fn predicate(error: T) -> Self {
+        Self {
+            kind: OnErrorKind::Predicate(error),
+        }
+    }
+
+    pub(super) fn project(error: U) -> Self {
+        Self {
+            kind: OnErrorKind::Project(error),
+        }
+    }
+}
+
+impl<T, U> From<OnError<T, U>> for Error
+where
+    Error: From<T> + From<U>,
+{
+    fn from(error: OnError<T, U>) -> Self {
+        match error.kind {
+            OnErrorKind::Predicate(error) => error.into(),
+            OnErrorKind::Project(error) => error.into(),
+        }
+    }
+}
+
+impl From<EmptyQuery> for Error {
+    fn from(_: EmptyQuery) -> Self {
+        err!(400, "request uri query cannot be empty.")
+    }
+}

--- a/via/src/guard/error.rs
+++ b/via/src/guard/error.rs
@@ -10,15 +10,17 @@ pub struct MissingUriQuery;
 /// The request is missing an extension.
 pub struct UnknownExtension;
 
+/// The error type returned by the [`into_error`] combinator.
+///
+/// [`into_error`]: super::into_error
+pub struct ErrorThunk<'a, F, E> {
+    op: &'a F,
+    error: E,
+}
+
 /// A request header is either missing or invalid.
 pub struct InvalidHeader<'a> {
     source: OnError<&'a HeaderName, &'a HeaderName>,
-}
-
-/// The error type returned by the [`map_err`](super::map_err) predicate.
-pub struct MapError<'a, F, E> {
-    op: &'a F,
-    error: E,
 }
 
 /// A contextual, `405 Method Not Allowed` error.
@@ -33,17 +35,17 @@ pub enum OnError<T, U> {
     Project(U),
 }
 
-impl<'a, F, E> MapError<'a, F, E> {
+impl<'a, F, E> ErrorThunk<'a, F, E> {
     pub(super) fn new(op: &'a F, error: E) -> Self {
         Self { op, error }
     }
 }
 
-impl<F, E> From<MapError<'_, F, E>> for Error
+impl<F, E> From<ErrorThunk<'_, F, E>> for Error
 where
     F: Fn(E) -> Error,
 {
-    fn from(into: MapError<'_, F, E>) -> Self {
+    fn from(into: ErrorThunk<'_, F, E>) -> Self {
         (into.op)(into.error)
     }
 }

--- a/via/src/guard/header.rs
+++ b/via/src/guard/header.rs
@@ -1,16 +1,10 @@
-//! Match on a header.
-
-pub mod media;
-
-mod value;
-
-pub use media::Media;
-pub use value::*;
+//! Well-known request header combinators and predicates.
 
 use http::header::{self as h, HeaderMap, HeaderName};
 use std::fmt::Debug;
 
-use super::{Predicate, Wildcard, header, or, wildcard};
+use super::bytes::{Contains, contains};
+use super::{Any, Predicate, any, media, or};
 use crate::request::Request;
 use crate::{Error, err};
 
@@ -33,18 +27,9 @@ pub struct Header<T> {
     pub(super) key: HeaderName,
 }
 
-/// The header associated with `key` must be present in the request.
-pub fn exists<K>(key: K) -> Header<Wildcard>
-where
-    K: TryInto<HeaderName>,
-    K::Error: Debug,
-{
-    header(key, wildcard())
-}
-
 /// The value of `Accept` must include `"*/*"` or match `predicate`.
 pub fn accept<T>(predicate: T) -> Header<Contains<media::AllOr<T>>> {
-    header(h::ACCEPT, contains(or((media::all(), predicate))))
+    header(h::ACCEPT, contains(or((media::all(), predicate)), b','))
 }
 
 /// The value of `Content-Type` must match `predicate`.
@@ -53,8 +38,29 @@ pub fn content_type<T>(predicate: T) -> Header<T> {
 }
 
 /// The `Content-Length` header must be present in the request.
-pub fn content_length() -> Header<Wildcard> {
+pub fn content_length() -> Header<Any> {
     exists(h::CONTENT_LENGTH)
+}
+
+/// The header associated with `key` must be present in the request.
+pub fn exists<K>(key: K) -> Header<Any>
+where
+    K: TryInto<HeaderName>,
+    K::Error: Debug,
+{
+    header(key, any())
+}
+
+/// Require that the header associated with `key` matches `predicate`.
+pub fn header<K, V>(key: K, value: V) -> Header<V>
+where
+    K: TryInto<http::HeaderName>,
+    K::Error: Debug,
+{
+    Header {
+        value,
+        key: key.try_into().expect("invalid header name."),
+    }
 }
 
 impl<T> Header<T> {

--- a/via/src/guard/header.rs
+++ b/via/src/guard/header.rs
@@ -1,27 +1,33 @@
-//! Well-known request header combinators and predicates.
+//! Predicate combinators for testing request headers.
 
 use http::header::{self as h, HeaderMap, HeaderName};
 use std::fmt::Debug;
 
-use super::bytes::{Contains, contains};
+use super::bytes::{Contains, Trim, contains, trim};
 use super::error::{InvalidHeader, OnError};
 use super::on::{self, On};
 use super::{Any, OkOr, Predicate, any, media, ok_or, or};
 use crate::Request;
 
-/// Require that a header associated with a key matches a predicate.
+/// The value predicate of an `Accept` header.
+pub type Accept<T> = Contains<Trim<media::AllOr<T>>>;
+
+/// Require that the header for `key` matches `value`.
 pub struct Header<T> {
     predicate: On<OkOr<T, HeaderName>, on::Header>,
 }
 
-/// When present, require that the header value for `key` matches `value`.
+/// When present, require that the header for `key` matches `value`.
 pub struct Opt<T> {
     predicate: on::Opt<OkOr<T, HeaderName>, on::Header>,
 }
 
 /// The value of `Accept` must include `"*/*"` or match `predicate`.
-pub fn accept<T>(predicate: T) -> Header<Contains<media::AllOr<T>>> {
-    header(h::ACCEPT, contains(or((media::all(), predicate)), b','))
+pub fn accept<T>(predicate: T) -> Header<Accept<T>> {
+    header(
+        h::ACCEPT,
+        contains(trim(or((media::all(), predicate))), b','),
+    )
 }
 
 /// The value of `Content-Type` must match `predicate`.

--- a/via/src/guard/header.rs
+++ b/via/src/guard/header.rs
@@ -4,27 +4,19 @@ use http::header::{self as h, HeaderMap, HeaderName};
 use std::fmt::Debug;
 
 use super::bytes::{Contains, contains};
-use super::{Any, Predicate, any, media, or};
-use crate::request::Request;
-use crate::{Error, err};
-
-/// Treat the predicate as match if the header is `None`.
-pub struct Optional<T>(T);
-
-/// A header predicate does not match the request.
-#[derive(Debug)]
-pub enum DenyHeader<'a> {
-    /// The predicate does not match the header value.
-    Predicate(&'a HeaderName),
-
-    /// The header is not present on the request.
-    Missing(&'a HeaderName),
-}
+use super::error::{InvalidHeader, OnError};
+use super::on::{self, On};
+use super::{Any, OkOr, Predicate, any, media, ok_or, or};
+use crate::Request;
 
 /// Require that a header associated with a key matches a predicate.
 pub struct Header<T> {
-    pub(super) value: T,
-    pub(super) key: HeaderName,
+    predicate: On<OkOr<T, HeaderName>, on::Header>,
+}
+
+/// When present, require that the header value for `key` matches `value`.
+pub struct Opt<T> {
+    predicate: on::Opt<OkOr<T, HeaderName>, on::Header>,
 }
 
 /// The value of `Accept` must include `"*/*"` or match `predicate`.
@@ -57,16 +49,20 @@ where
     K: TryInto<http::HeaderName>,
     K::Error: Debug,
 {
+    let key = key.try_into().expect("invalid header name");
+    let value = ok_or(value, key.clone());
+
     Header {
-        value,
-        key: key.try_into().expect("invalid header name."),
+        predicate: on::header(value, key),
     }
 }
 
 impl<T> Header<T> {
-    /// If the header associated with  the predicate as match if the header is `None`.
-    pub fn optional(self) -> Optional<Self> {
-        Optional(self)
+    /// Make the header associated with `key`, optional.
+    pub fn opt(self) -> Opt<T> {
+        Opt {
+            predicate: self.predicate.opt(),
+        }
     }
 }
 
@@ -74,17 +70,10 @@ impl<T> Predicate<HeaderMap> for Header<T>
 where
     for<'a> T: Predicate<[u8]> + 'a,
 {
-    type Error<'a> = DenyHeader<'a>;
+    type Error<'a> = InvalidHeader<'a>;
 
     fn cmp<'a>(&'a self, headers: &HeaderMap) -> Result<(), Self::Error<'a>> {
-        let key = &self.key;
-        let Some(value) = headers.get(key) else {
-            return Err(DenyHeader::Missing(key));
-        };
-
-        self.value
-            .cmp(value.as_bytes().trim_ascii())
-            .map_err(|_| DenyHeader::Predicate(key))
+        self.predicate.cmp(headers).map_err(InvalidHeader::new)
     }
 }
 
@@ -92,62 +81,33 @@ impl<T, App> Predicate<Request<App>> for Header<T>
 where
     for<'a> T: Predicate<[u8]> + 'a,
 {
-    type Error<'a> = DenyHeader<'a>;
+    type Error<'a> = InvalidHeader<'a>;
 
     fn cmp<'a>(&'a self, request: &Request<App>) -> Result<(), Self::Error<'a>> {
         self.cmp(request.headers())
     }
 }
 
-impl<T, Input> Predicate<Input> for Optional<T>
+impl<T> Predicate<HeaderMap> for Opt<T>
 where
-    for<'a> T: Predicate<Input, Error<'a> = DenyHeader<'a>> + 'a,
+    for<'a> T: Predicate<[u8]> + 'a,
 {
-    type Error<'a> = DenyHeader<'a>;
+    type Error<'a> = InvalidHeader<'a>;
 
-    fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
-        self.0.cmp(input).or_else(|error| match error {
-            DenyHeader::Missing(_) => Ok(()),
-            error => Err(error),
-        })
+    fn cmp<'a>(&'a self, headers: &HeaderMap) -> Result<(), Self::Error<'a>> {
+        self.predicate
+            .cmp(headers)
+            .map_err(|error| InvalidHeader::new(OnError::Predicate(error)))
     }
 }
 
-impl<'a> DenyHeader<'a> {
-    /// Returns a reference to the name of the header associated with the
-    /// predicate error.
-    pub fn name(&self) -> &'a HeaderName {
-        match *self {
-            Self::Predicate(name) | Self::Missing(name) => name,
-        }
-    }
-}
+impl<T, App> Predicate<Request<App>> for Opt<T>
+where
+    for<'a> T: Predicate<[u8]> + 'a,
+{
+    type Error<'a> = InvalidHeader<'a>;
 
-impl From<DenyHeader<'_>> for Error {
-    fn from(error: DenyHeader<'_>) -> Self {
-        match error {
-            DenyHeader::Predicate(name) => match name.as_str() {
-                "accept" => err!(406, "response media type not supported."),
-                "authorization" => err!(401, "unauthorized."),
-                "content-type" => err!(415, "request media type not supported."),
-                "range" => err!(416, "unsatisfiable range request."),
-                "upgrade" => err!(426, "protocol upgrade is not supported."),
-                n => err!(400, "invalid value for header: {}.", n),
-            },
-            DenyHeader::Missing(name) => match name.as_str() {
-                "content-length" => err!(411, "length required."),
-
-                if_ @ ("if-match"
-                | "if-none-match"
-                | "if-modified-since"
-                | "if-unmodified-since") => {
-                    err!(428, "missing required precondition: {}.", if_)
-                }
-
-                n => {
-                    err!(400, "invalid value for header: {}.", n)
-                }
-            },
-        }
+    fn cmp<'a>(&'a self, request: &Request<App>) -> Result<(), Self::Error<'a>> {
+        self.cmp(request.headers())
     }
 }

--- a/via/src/guard/media.rs
+++ b/via/src/guard/media.rs
@@ -1,10 +1,10 @@
 //! Predicate combinators for HTTP media types.
 
-use crate::guard::bytes::{CaseSensitive, Tag, case_sensitive, tag};
+use crate::guard::bytes::{Tag, TagNoCase, tag, tag_no_case};
 use crate::guard::{Or, Predicate};
 
 /// Match `"*/*"(; charset=*)?` or predicate `T`.
-pub type AllOr<T> = Or<(Media<CaseSensitive>, T)>;
+pub type AllOr<T> = Or<(Media<TagNoCase>, T)>;
 
 /// An essence string with an optional charset.
 ///
@@ -13,8 +13,8 @@ pub type AllOr<T> = Or<(Media<CaseSensitive>, T)>;
 pub struct Media<T = Tag>(T, Option<Tag>);
 
 /// Match `"*/*"(; charset=*)?`.
-pub fn all() -> Media<CaseSensitive> {
-    media(case_sensitive(b"*/*"), None)
+pub fn all() -> Media<TagNoCase> {
+    media(tag_no_case(b"*/*"), None)
 }
 
 /// Match `"text/html"(; charset=utf-8)?`.

--- a/via/src/guard/media.rs
+++ b/via/src/guard/media.rs
@@ -1,6 +1,6 @@
-//! Value combinators for HTTP media types.
+//! Predicate combinators for HTTP media types.
 
-use super::{CaseSensitive, Tag, case_sensitive, tag};
+use crate::guard::bytes::{CaseSensitive, Tag, case_sensitive, tag};
 use crate::guard::{Or, Predicate};
 
 /// Match `"*/*"(; charset=*)?` or predicate `T`.

--- a/via/src/guard/media.rs
+++ b/via/src/guard/media.rs
@@ -1,10 +1,10 @@
 //! Predicate combinators for HTTP media types.
 
-use crate::guard::bytes::{Tag, TagNoCase, tag, tag_no_case};
+use crate::guard::bytes::{CaseSensitive, Tag, case_sensitive, tag};
 use crate::guard::{Or, Predicate};
 
 /// Match `"*/*"(; charset=*)?` or predicate `T`.
-pub type AllOr<T> = Or<(Media<TagNoCase>, T)>;
+pub type AllOr<T> = Or<(Media<CaseSensitive>, T)>;
 
 /// An essence string with an optional charset.
 ///
@@ -13,8 +13,8 @@ pub type AllOr<T> = Or<(Media<TagNoCase>, T)>;
 pub struct Media<T = Tag>(T, Option<Tag>);
 
 /// Match `"*/*"(; charset=*)?`.
-pub fn all() -> Media<TagNoCase> {
-    media(tag_no_case(b"*/*"), None)
+pub fn all() -> Media<CaseSensitive> {
+    media(case_sensitive(b"*/*"), None)
 }
 
 /// Match `"text/html"(; charset=utf-8)?`.

--- a/via/src/guard/method.rs
+++ b/via/src/guard/method.rs
@@ -177,9 +177,9 @@ pub fn is_safe() -> IsSafe {
 ///
 /// ```
 /// use http::Method;
-/// use via::guard::{Predicate, method::allow};
+/// use via::guard::{Predicate, method};
 ///
-/// let predicate = allow(Method::POST);
+/// let predicate = method(Method::POST);
 ///
 /// assert!(predicate.cmp(&Method::POST).is_ok());
 /// assert!(predicate.cmp(&Method::GET).is_err());

--- a/via/src/guard/method.rs
+++ b/via/src/guard/method.rs
@@ -7,10 +7,9 @@
 //! [`on`], while the implementations for request make the common case
 //! straightforward.
 //!
-//! [`Allow`] is the only contextual predicate in this module. When evaluated
-//! against a method, it behaves like a boolean predicate. When evaluated
-//! against a request, it returns a [contextual error](Deny) that can be
-//! converted into a `405 Method Not Allowed` response.
+//! [`Method`] is the only contextual predicate in this module. When evaluated
+//! against an input type, it returns a [contextual error] that can be into a
+//! response with a `405` status code.
 //!
 //! ## Method Predicates and Method Switches
 //!
@@ -61,6 +60,7 @@
 //! [`Request`]: crate::Request
 //! [`Switch`]: crate::router::Switch
 //! [`barrier`]: crate::guard::barrier
+//! [contextual error]: crate::guard::error::MethodNotAllowed
 //! [`filter`]: crate::guard::filter
 //! [`flat_map`]: crate::guard::flat_map
 //! [`get`]: crate::get
@@ -97,10 +97,11 @@ pub struct IsSafe;
 ///
 /// When evaluated against a [`Method`] this predicate behaves like a boolean.
 /// When evaluated against a [`Request`], this predicate can return a
-/// [contextual error](Deny) when the request method does not match.
+/// [contextual error] when the request method does not match.
 ///
 /// [`Method`]: http::Method
 /// [`Request`]: crate::Request
+/// [contextual error]: crate::guard::error::MethodNotAllowed
 pub struct Method {
     allow: http::Method,
 }

--- a/via/src/guard/method.rs
+++ b/via/src/guard/method.rs
@@ -4,8 +4,8 @@
 //! [`Request`].
 //!
 //! The implementations for method are useful with projection combinators like
-//! [`on`], while the implementations for request make the common case
-//! straightforward.
+//! those found in the [`on`] module, while the implementations for request
+//! make the common case straightforward.
 //!
 //! [`Method`] is the only contextual predicate in this module. When evaluated
 //! against an input type, it returns a [contextual error] that can be into a
@@ -64,7 +64,7 @@
 //! [`filter`]: crate::guard::filter
 //! [`flat_map`]: crate::guard::flat_map
 //! [`get`]: crate::get
-//! [`on`]: fn@crate::guard::on
+//! [`on`]: mod@crate::guard::on
 //! [`post`]: crate::post
 //! [`put`]: crate::put
 

--- a/via/src/guard/method.rs
+++ b/via/src/guard/method.rs
@@ -68,10 +68,9 @@
 //! [`post`]: crate::post
 //! [`put`]: crate::put
 
-use http::Method;
-
+use super::error::MethodNotAllowed;
 use super::predicate::{Not, Predicate, not};
-use crate::{Error, err, request::Request};
+use crate::request::Request;
 
 /// Match request methods that are
 /// ["idempotent"](https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods).
@@ -102,35 +101,8 @@ pub struct IsSafe;
 ///
 /// [`Method`]: http::Method
 /// [`Request`]: crate::Request
-pub struct Allow {
-    method: Method,
-}
-
-/// A contextual, `405 Method Not Allowed` error.
-///
-/// `Deny` borrows the method allowed by the predicate. It does not
-/// borrow the method supplied by the request.
-pub struct Deny<'a> {
-    allow: &'a Method,
-}
-
-/// Succeeds for requests made with the provided method argument.
-///
-/// The returned predicate succeeds when the input method is equal to `method`.
-///
-/// # Example
-///
-/// ```
-/// use http::Method;
-/// use via::guard::{Predicate, method::allow};
-///
-/// let predicate = allow(Method::POST);
-///
-/// assert!(predicate.cmp(&Method::POST).is_ok());
-/// assert!(predicate.cmp(&Method::GET).is_err());
-/// ```
-pub fn allow(method: Method) -> Allow {
-    Allow { method }
+pub struct Method {
+    allow: http::Method,
 }
 
 /// Succeeds for request methods that are
@@ -196,38 +168,51 @@ pub fn is_safe() -> IsSafe {
     IsSafe
 }
 
-impl Predicate<Method> for Allow {
-    type Error<'a> = ();
+/// Succeeds for requests made with the provided method argument.
+///
+/// The returned predicate succeeds when the input method is equal to `method`.
+///
+/// # Example
+///
+/// ```
+/// use http::Method;
+/// use via::guard::{Predicate, method::allow};
+///
+/// let predicate = allow(Method::POST);
+///
+/// assert!(predicate.cmp(&Method::POST).is_ok());
+/// assert!(predicate.cmp(&Method::GET).is_err());
+/// ```
+pub fn method(allow: http::Method) -> Method {
+    Method { allow }
+}
 
-    fn cmp<'a>(&'a self, input: &Method) -> Result<(), Self::Error<'a>> {
-        if self.method == input {
+impl Predicate<http::Method> for Method {
+    type Error<'a> = MethodNotAllowed<'a>;
+
+    fn cmp<'a>(&'a self, input: &http::Method) -> Result<(), Self::Error<'a>> {
+        let method = &self.allow;
+
+        if method == input {
             Ok(())
         } else {
-            Err(())
+            Err(MethodNotAllowed::new(method))
         }
     }
 }
 
-impl<App> Predicate<Request<App>> for Allow {
-    type Error<'a> = Deny<'a>;
+impl<App> Predicate<Request<App>> for Method {
+    type Error<'a> = MethodNotAllowed<'a>;
 
     fn cmp<'a>(&'a self, request: &Request<App>) -> Result<(), Self::Error<'a>> {
-        self.cmp(request.method()).map_err(|_| Deny {
-            allow: &self.method,
-        })
+        self.cmp(request.method())
     }
 }
 
-impl From<Deny<'_>> for Error {
-    fn from(error: Deny<'_>) -> Self {
-        err!(405, "expected request method to be {}", &error.allow)
-    }
-}
-
-impl Predicate<Method> for IsIdempotent {
+impl Predicate<http::Method> for IsIdempotent {
     type Error<'a> = ();
 
-    fn cmp<'a>(&'a self, input: &Method) -> Result<(), Self::Error<'a>> {
+    fn cmp<'a>(&'a self, input: &http::Method) -> Result<(), Self::Error<'a>> {
         if input.is_idempotent() {
             Ok(())
         } else {
@@ -244,10 +229,10 @@ impl<App> Predicate<Request<App>> for IsIdempotent {
     }
 }
 
-impl Predicate<Method> for IsSafe {
+impl Predicate<http::Method> for IsSafe {
     type Error<'a> = ();
 
-    fn cmp<'a>(&'a self, input: &Method) -> Result<(), Self::Error<'a>> {
+    fn cmp<'a>(&'a self, input: &http::Method) -> Result<(), Self::Error<'a>> {
         if input.is_safe() { Ok(()) } else { Err(()) }
     }
 }

--- a/via/src/guard/method.rs
+++ b/via/src/guard/method.rs
@@ -82,7 +82,7 @@ use crate::request::Request;
 /// or replay semantics are acceptable.
 ///
 /// [`Method::is_idempotent`]: http::Method::is_idempotent
-pub struct IsIdempotent;
+pub struct Idempotent;
 
 /// Match `GET`, `HEAD`, `OPTIONS`, and `TRACE` requests.
 ///
@@ -91,7 +91,7 @@ pub struct IsIdempotent;
 /// methods are read-only by convention.
 ///
 /// [`Method::is_safe`]: http::Method::is_safe
-pub struct IsSafe;
+pub struct Safe;
 
 /// Match requests made with the provided method argument.
 ///
@@ -104,6 +104,17 @@ pub struct IsSafe;
 /// [contextual error]: crate::guard::error::MethodNotAllowed
 pub struct Method {
     allow: http::Method,
+}
+
+macro_rules! methods {
+    ($($vis:vis fn $name:ident($method:ident));+ $(;)?) => {
+        $(
+            #[doc = concat!("A predicate that succeeds for `", stringify!($method), "` requests.")]
+            $vis fn $name() -> Method {
+                Method { allow: http::Method::$method }
+            }
+        )+
+    };
 }
 
 /// Succeeds for request methods that are
@@ -125,8 +136,8 @@ pub struct Method {
 /// ```
 ///
 /// [`Method::is_idempotent`]: http::Method::is_idempotent
-pub fn is_idempotent() -> IsIdempotent {
-    IsIdempotent
+pub fn is_idempotent() -> Idempotent {
+    Idempotent
 }
 
 /// Succeeds for request methods that are not
@@ -145,7 +156,7 @@ pub fn is_idempotent() -> IsIdempotent {
 /// ```
 ///
 /// [`is_safe`]: crate::guard::method::is_safe
-pub fn is_mutation() -> Not<IsSafe> {
+pub fn is_mutation() -> Not<Safe> {
     not(is_safe())
 }
 
@@ -165,27 +176,20 @@ pub fn is_mutation() -> Not<IsSafe> {
 ///
 /// assert!(method::is_safe().cmp(&Method::POST).is_err());
 /// ```
-pub fn is_safe() -> IsSafe {
-    IsSafe
+pub fn is_safe() -> Safe {
+    Safe
 }
 
-/// Succeeds for requests made with the provided method argument.
-///
-/// The returned predicate succeeds when the input method is equal to `method`.
-///
-/// # Example
-///
-/// ```
-/// use http::Method;
-/// use via::guard::{Predicate, method};
-///
-/// let predicate = method(Method::POST);
-///
-/// assert!(predicate.cmp(&Method::POST).is_ok());
-/// assert!(predicate.cmp(&Method::GET).is_err());
-/// ```
-pub fn method(allow: http::Method) -> Method {
-    Method { allow }
+methods! {
+    pub fn connect(CONNECT);
+    pub fn delete(DELETE);
+    pub fn get(GET);
+    pub fn head(HEAD);
+    pub fn options(OPTIONS);
+    pub fn patch(PATCH);
+    pub fn post(POST);
+    pub fn put(PUT);
+    pub fn trace(TRACE);
 }
 
 impl Predicate<http::Method> for Method {
@@ -210,10 +214,10 @@ impl<App> Predicate<Request<App>> for Method {
     }
 }
 
-impl Predicate<http::Method> for IsIdempotent {
+impl Predicate<http::Method> for Idempotent {
     type Error<'a> = ();
 
-    fn cmp<'a>(&'a self, input: &http::Method) -> Result<(), Self::Error<'a>> {
+    fn cmp(&self, input: &http::Method) -> Result<(), ()> {
         if input.is_idempotent() {
             Ok(())
         } else {
@@ -222,26 +226,26 @@ impl Predicate<http::Method> for IsIdempotent {
     }
 }
 
-impl<App> Predicate<Request<App>> for IsIdempotent {
+impl<App> Predicate<Request<App>> for Idempotent {
     type Error<'a> = ();
 
-    fn cmp<'a>(&'a self, request: &Request<App>) -> Result<(), Self::Error<'a>> {
+    fn cmp(&self, request: &Request<App>) -> Result<(), ()> {
         self.cmp(request.method())
     }
 }
 
-impl Predicate<http::Method> for IsSafe {
+impl Predicate<http::Method> for Safe {
     type Error<'a> = ();
 
-    fn cmp<'a>(&'a self, input: &http::Method) -> Result<(), Self::Error<'a>> {
+    fn cmp(&self, input: &http::Method) -> Result<(), ()> {
         if input.is_safe() { Ok(()) } else { Err(()) }
     }
 }
 
-impl<App> Predicate<Request<App>> for IsSafe {
+impl<App> Predicate<Request<App>> for Safe {
     type Error<'a> = ();
 
-    fn cmp<'a>(&'a self, request: &Request<App>) -> Result<(), Self::Error<'a>> {
+    fn cmp(&self, request: &Request<App>) -> Result<(), ()> {
         self.cmp(request.method())
     }
 }

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -71,7 +71,7 @@ pub struct FlatMap<T, U> {
 /// let mut api = app.route("/api");
 ///
 /// // If the client does not speak JSON, deny the request.
-/// api.middleware(guard::barrier(guard::content!(media::json)));
+/// api.middleware(guard::barrier(guard::content!(media::json())));
 ///
 /// // Subsequent routes defined from `api` require:
 /// //   - accept: application/json [; charset=utf-8], */*

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -9,7 +9,7 @@ mod predicate;
 
 pub use header::{Header, header};
 pub use method::Method;
-pub use on::{On, on};
+pub use on::{On, Project, on};
 pub use predicate::*;
 
 pub use via_macros::content;

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -1,26 +1,21 @@
+pub mod bytes;
+pub mod error;
 pub mod header;
+pub mod media;
 pub mod method;
 pub mod on;
 
 mod predicate;
 
-pub use header::Header;
-#[doc(inline)]
+pub use header::{Header, header};
+pub use method::{Method, method};
 pub use on::{On, on};
 pub use predicate::*;
 
 pub use via_macros::content;
 
-use std::fmt::Debug;
-
 use crate::request::Request;
 use crate::{BoxFuture, Continue, Error, Middleware, Next};
-
-/// Content negotation as validation.
-pub type Content<T, U> = (
-    Header<header::Contains<Or<(header::Media<header::CaseSensitive>, U)>>>,
-    When<Not<method::IsSafe>, on::Headers<(Header<T>, Header<Wildcard>)>>,
-);
 
 /// Skip a middleware if the guard's predicate does not match the request.
 ///
@@ -102,18 +97,6 @@ pub fn flat_map<T, U>(predicate: T, middleware: U) -> FlatMap<T, U> {
     FlatMap {
         predicate,
         middleware,
-    }
-}
-
-/// Require that the header associated with `key` matches `predicate`.
-pub fn header<K, V>(key: K, value: V) -> Header<V>
-where
-    K: TryInto<http::HeaderName>,
-    K::Error: Debug,
-{
-    Header {
-        value,
-        key: key.try_into().expect("invalid header name."),
     }
 }
 

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -1,3 +1,9 @@
+//! Synchronous predicates that shape middleware execution.
+//!
+//! Guards are stateless higher-order middleware. They classify a request before
+//! asynchronous work begins and decide whether middleware should be entered or
+//! skipped entirely.
+
 pub mod bytes;
 pub mod error;
 pub mod header;

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -59,7 +59,7 @@ pub struct FlatMap<T, U> {
 /// # Example
 ///
 /// ```rust
-/// use via::guard::{self, header::media};
+/// use via::guard::{self, media};
 ///
 /// let mut app = via::app(());
 /// let mut api = app.route("/api");

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -8,7 +8,7 @@ pub mod on;
 mod predicate;
 
 pub use header::{Header, header};
-pub use method::{Method, method};
+pub use method::Method;
 pub use on::{On, on};
 pub use predicate::*;
 

--- a/via/src/guard/on/mod.rs
+++ b/via/src/guard/on/mod.rs
@@ -62,11 +62,15 @@ pub fn headers<T>(predicate: T) -> On<T, Headers> {
 /// # Example
 ///
 /// ```
-/// use http::Method;
 /// use via::guard::{self, on, method};
+/// use via::{Request, Next};
 ///
-/// let patch_or_put = guard::or((method(Method::PATCH), method(Method::PUT)));
-/// let predicate = on::method(patch_or_put);;
+/// let update = guard::flat_map(
+///     on::method(guard::or((method::patch(), method::put()))),
+///     async |_: Request, _: Next| {
+///         todo!("update the resource that matches the uri path");
+///     }
+/// );
 /// ```
 pub fn method<T>(predicate: T) -> On<T, Method> {
     on(predicate, Method)

--- a/via/src/guard/on/mod.rs
+++ b/via/src/guard/on/mod.rs
@@ -1,70 +1,12 @@
 //! Field projection helpers.
-//!
-//! This module adapts predicates written for one input type so they can be
-//! evaluated against another.
-//!
-//! Most domain predicates in `guard` are implemented for both their natural
-//! input type and [`Request`]. For example, header predicates can be evaluated
-//! against a [`HeaderMap`] directly, but they can also be evaluated against a
-//! [`Request`] for convenience.
-//!
-//! ```
-//! use via::guard::header::{self, media};
-//!
-//! let accepts_json = header::accept(media::json());
-//! ```
-//!
-//! Projection is useful when more than one predicate should be evaluated
-//! against the same projected value. Instead of allowing each predicate to
-//! independently access the same request field, [`on`] projects the field once
-//! and evaluates the composed predicate against that projected value.
-//!
-//! ```
-//! use via::guard::header::{self, media};
-//! use via::guard::on;
-//!
-//! let content = on::headers((
-//!     header::accept(media::json()),
-//!     header::content_type(media::json()),
-//!     header::content_length(),
-//! ));
-//! ```
-//!
-//! The same pattern can be applied to the request method:
-//!
-//! ```
-//! use http::Method;
-//! use via::guard::method::allow;
-//! use via::guard::{self, on};
-//!
-//! let is_safe = on::method(guard::or((
-//!     allow(Method::GET),
-//!     allow(Method::HEAD),
-//!     allow(Method::OPTIONS),
-//!     allow(Method::TRACE),
-//! )));
-//! ```
-//!
-//! Projection keeps predicates reusable without making request evaluation
-//! depend on optimizer common-subexpression elimination. Predicates can be
-//! written for their smallest natural input, such as [`HeaderMap`] or
-//! [`http::Method`], and then lifted to [`Request`] only when needed.
-//!
-//! Use the helpers in this module, such as [`headers`] and [`method`], when
-//! multiple predicates share a well-known request field. Use [`on`] directly
-//! for custom projections.
-//!
-//! [`HeaderMap`]: http::HeaderMap
 
 mod project;
 
+use http::HeaderName;
 pub use project::*;
 
 use super::Predicate;
-use super::error::{OnError, OnErrorKind};
-
-/// Make a predicate's projected input optional.
-pub struct Opt<T, U>(On<T, U>);
+use super::error::OnError;
 
 /// Apply a predicate to a projected field.
 ///
@@ -81,20 +23,16 @@ pub struct On<T, U> {
     projector: U,
 }
 
+/// Make a predicate's projected input optional.
+pub struct Opt<T, U> {
+    predicate: T,
+    projector: U,
+}
+
 /// Project a field before evaluating a predicate.
 ///
 /// The returned predicate first applies `project` to the input and then
 /// evaluates `predicate` against the projected value.
-///
-/// # Example
-///
-/// ```
-/// use via::guard::header::media;
-/// use via::guard::on::project;
-/// use via::guard::{header, on};
-///
-/// let predicate = on(project::Headers, header::accept(media::json()));
-/// ```
 pub fn on<T, U>(predicate: T, projector: U) -> On<T, U> {
     On {
         predicate,
@@ -103,39 +41,19 @@ pub fn on<T, U>(predicate: T, projector: U) -> On<T, U> {
 }
 
 /// Evaluate a predicate against a request's headers.
-///
-/// This is a convenience wrapper around [`on`] that projects
-/// [`Request::headers`].
-///
-/// # Example
-///
-/// ```
-/// use via::guard::header::media;
-/// use via::guard::{header, on};
-///
-/// // Requests bodies are JSON and have a known length.
-/// let predicate = on::headers((
-///     header::content_length(),
-///     header::content_type(media::json()),
-/// ));
-/// ```
 pub fn headers<T>(predicate: T) -> On<T, Headers> {
     on(predicate, project::Headers)
 }
 
 /// Evaluate a predicate against a request's method.
 ///
-/// This is a convenience wrapper around [`on`] that projects
-/// [`Request::method`].
-///
 /// # Example
 ///
 /// ```
 /// use http::Method;
-/// use via::guard::method::allow;
-/// use via::guard::{self, on};
+/// use via::guard::{self, on, method};
 ///
-/// let patch_or_put = guard::or((allow(Method::PATCH), allow(Method::PUT)));
+/// let patch_or_put = guard::or((method(Method::PATCH), method(Method::PUT)));
 /// let predicate = on::method(patch_or_put);;
 /// ```
 pub fn method<T>(predicate: T) -> On<T, Method> {
@@ -154,12 +72,19 @@ pub fn uri<T>(predicate: T) -> On<T, Uri> {
     on(predicate, Uri)
 }
 
+pub(super) fn header<T>(predicate: T, name: HeaderName) -> On<T, Header> {
+    on(predicate, Header { name })
+}
+
 impl<T, U> On<T, U> {
     /// Make the predicate's projected input optional.
     ///
     /// If the field projection fails, the predicate returns `Ok(())`.
     pub fn opt(self) -> Opt<T, U> {
-        Opt(self)
+        Opt {
+            predicate: self.predicate,
+            projector: self.projector,
+        }
     }
 }
 
@@ -168,13 +93,13 @@ where
     for<'a> T: Predicate<U::Output> + 'a,
     for<'a> U: Project<Input> + 'a,
 {
-    type Error<'a> = OnError<T::Error<'a>, U::Error>;
+    type Error<'a> = OnError<T::Error<'a>, U::Error<'a>>;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
         self.projector
             .project(input)
-            .map_err(OnError::project)
-            .and_then(|input| self.predicate.cmp(input).map_err(OnError::predicate))
+            .map_err(OnError::Project)
+            .and_then(|input| self.predicate.cmp(input).map_err(OnError::Predicate))
     }
 }
 
@@ -186,9 +111,8 @@ where
     type Error<'a> = T::Error<'a>;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
-        self.0.cmp(input).or_else(|error| match error.kind {
-            OnErrorKind::Predicate(error) => Err(error),
-            OnErrorKind::Project(_) => Ok(()),
-        })
+        self.projector
+            .project(input)
+            .map_or(Ok(()), |input| self.predicate.cmp(input))
     }
 }

--- a/via/src/guard/on/mod.rs
+++ b/via/src/guard/on/mod.rs
@@ -2,6 +2,8 @@
 
 mod project;
 
+use std::marker::PhantomData;
+
 use http::HeaderName;
 pub use project::*;
 
@@ -40,12 +42,22 @@ pub fn on<T, U>(predicate: T, projector: U) -> On<T, U> {
     }
 }
 
-/// Evaluate a predicate against a request's headers.
-pub fn headers<T>(predicate: T) -> On<T, Headers> {
-    on(predicate, project::Headers)
+/// Evaluate `predicate` against the request extensions.
+pub fn extensions<T>(predicate: T) -> On<T, Extensions> {
+    on(predicate, Extensions)
 }
 
-/// Evaluate a predicate against a request's method.
+/// Evaluate `predicate` against the request extension of type `U`.
+pub fn extension<T, U>(predicate: T) -> On<T, Extension<U>> {
+    on(predicate, Extension { _ty: PhantomData })
+}
+
+/// Evaluate `predicate` against a request's headers.
+pub fn headers<T>(predicate: T) -> On<T, Headers> {
+    on(predicate, Headers)
+}
+
+/// Evaluate `predicate` against a request's method.
 ///
 /// # Example
 ///
@@ -60,14 +72,17 @@ pub fn method<T>(predicate: T) -> On<T, Method> {
     on(predicate, Method)
 }
 
+/// Evaluate `predicate` against the request URI path.
 pub fn path<T>(predicate: T) -> On<T, Path> {
     on(predicate, Path)
 }
 
+/// Evaluate `predicate` against the request URI query.
 pub fn query<T>(predicate: T) -> On<T, Query> {
     on(predicate, Query)
 }
 
+/// Evaluate `predicate` against the request URI.
 pub fn uri<T>(predicate: T) -> On<T, Uri> {
     on(predicate, Uri)
 }

--- a/via/src/guard/on/mod.rs
+++ b/via/src/guard/on/mod.rs
@@ -56,43 +56,15 @@
 //!
 //! [`HeaderMap`]: http::HeaderMap
 
-pub mod project;
+mod project;
 
-pub use project::Project;
+pub use project::*;
 
 use super::Predicate;
+use super::error::{OnError, OnErrorKind};
 
-/// A predicate that projects a request's headers before evaluation.
-///
-/// `Headers<T>` adapts a predicate over [`http::HeaderMap`] so that it may be
-/// evaluated directly against a [`Request`].
-///
-/// # Example
-///
-/// ```
-/// use via::guard::header::media;
-/// use via::guard::{on, header};
-///
-/// let predicate = on::headers(header::accept(media::json()));
-/// ```
-pub type Headers<T> = On<project::Headers, T>;
-
-/// A predicate that projects a request's method before evaluation.
-///
-/// `Method<T>` adapts a predicate over [`http::Method`] so that it may be
-/// evaluated directly against a [`Request`].
-///
-/// # Example
-///
-/// ```
-/// use http::Method;
-/// use via::guard::method::allow;
-/// use via::guard::{self, on};
-///
-/// let patch_or_put = guard::or((allow(Method::PATCH), allow(Method::PUT)));
-/// let predicate = on::method(patch_or_put);
-/// ```
-pub type Method<T> = On<project::Method, T>;
+/// Make a predicate's projected input optional.
+pub struct Opt<T, U>(On<T, U>);
 
 /// Apply a predicate to a projected field.
 ///
@@ -105,8 +77,8 @@ pub type Method<T> = On<project::Method, T>;
 /// Most applications should prefer the helper functions in the [`on`] module
 /// rather than constructing `On` directly.
 pub struct On<T, U> {
-    projector: T,
-    predicate: U,
+    predicate: T,
+    projector: U,
 }
 
 /// Project a field before evaluating a predicate.
@@ -123,10 +95,10 @@ pub struct On<T, U> {
 ///
 /// let predicate = on(project::Headers, header::accept(media::json()));
 /// ```
-pub fn on<T, U>(projector: T, predicate: U) -> On<T, U> {
+pub fn on<T, U>(predicate: T, projector: U) -> On<T, U> {
     On {
-        projector,
         predicate,
+        projector,
     }
 }
 
@@ -147,8 +119,8 @@ pub fn on<T, U>(projector: T, predicate: U) -> On<T, U> {
 ///     header::content_type(media::json()),
 /// ));
 /// ```
-pub fn headers<T>(predicate: T) -> Headers<T> {
-    on(project::Headers, predicate)
+pub fn headers<T>(predicate: T) -> On<T, Headers> {
+    on(predicate, project::Headers)
 }
 
 /// Evaluate a predicate against a request's method.
@@ -166,19 +138,57 @@ pub fn headers<T>(predicate: T) -> Headers<T> {
 /// let patch_or_put = guard::or((allow(Method::PATCH), allow(Method::PUT)));
 /// let predicate = on::method(patch_or_put);;
 /// ```
-pub fn method<T>(predicate: T) -> Method<T> {
-    on(project::Method, predicate)
+pub fn method<T>(predicate: T) -> On<T, Method> {
+    on(predicate, Method)
+}
+
+pub fn path<T>(predicate: T) -> On<T, Path> {
+    on(predicate, Path)
+}
+
+pub fn query<T>(predicate: T) -> On<T, Query> {
+    on(predicate, Query)
+}
+
+pub fn uri<T>(predicate: T) -> On<T, Uri> {
+    on(predicate, Uri)
+}
+
+impl<T, U> On<T, U> {
+    /// Make the predicate's projected input optional.
+    ///
+    /// If the field projection fails, the predicate returns `Ok(())`.
+    pub fn opt(self) -> Opt<T, U> {
+        Opt(self)
+    }
 }
 
 impl<T, U, Input> Predicate<Input> for On<T, U>
 where
-    for<'a> T: Project<Input> + 'a,
-    for<'a> U: Predicate<T::Output> + 'a,
+    for<'a> T: Predicate<U::Output> + 'a,
+    for<'a> U: Project<Input> + 'a,
 {
-    type Error<'a> = U::Error<'a>;
+    type Error<'a> = OnError<T::Error<'a>, U::Error>;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
-        let project = self.projector.project(input);
-        self.predicate.cmp(project)
+        self.projector
+            .project(input)
+            .map_err(OnError::project)
+            .and_then(|input| self.predicate.cmp(input).map_err(OnError::predicate))
+    }
+}
+
+impl<T, U, Input> Predicate<Input> for Opt<T, U>
+where
+    for<'a> T: Predicate<U::Output> + 'a,
+    for<'a> U: Project<Input> + 'a,
+{
+    type Error<'a> = T::Error<'a>;
+
+    fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
+        self.0.cmp(input).or_else(|error| match error.kind {
+            OnErrorKind::Predicate(error) => Err(error),
+            OnErrorKind::Project(_) => Ok(()),
+        })
     }
 }

--- a/via/src/guard/on/project.rs
+++ b/via/src/guard/on/project.rs
@@ -29,7 +29,13 @@ pub struct Uri;
 /// Projects one input type into another.
 ///
 /// Projection allows a predicate written for a specific type to be reused
-/// against a larger structure.
+/// against a larger structure. It also prevents the lifetime of the input
+/// bubbling up to the bounds of a predicate combinator.
+///
+/// Without concrete projection types, the borrowed input that is passed to a
+/// predicate would have to live as long as self. This means that arbitrary
+/// unsanitized user input would be able to make it's way into error response
+/// or request logs.
 ///
 /// Most applications will use the helper functions provided by this module
 /// such as [`headers`] and [`method`] instead of implementing `Project`
@@ -38,15 +44,24 @@ pub struct Uri;
 /// # Example
 ///
 /// ```
-/// use via::guard::on::Project;
+/// use std::convert::Infallible;
+/// use via::guard::on::{On, Project};
 /// use via::{Request, guard};
 ///
-/// struct Path;
+/// pub struct Path;
+///
+/// pub fn project_path<T>(predicate: T) -> On<T, Path> {
+///     guard::on(predicate, Path)
+/// }
 ///
 /// impl<App> Project<Request<App>> for Path {
+///     type Error<'a> = Infallible; // Projections can fail with context.
 ///     type Output = str;
 ///
-///     fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+///     fn project<'a, 'b>(
+///         &'a self,
+///         request: &'b Request<App>,
+///     ) -> Result<&'b Self::Output, Self::Error<'a>> {
 ///         Ok(request.uri().path())
 ///     }
 /// }
@@ -80,10 +95,7 @@ impl<App> Project<Request<App>> for Extensions {
     type Error<'a> = Infallible;
     type Output = http::Extensions;
 
-    fn project<'a, 'b>(
-        &'a self,
-        request: &'b Request<App>,
-    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Infallible> {
         Ok(request.extensions())
     }
 }
@@ -95,11 +107,8 @@ where
     type Error<'a> = UnknownExtension;
     type Output = T;
 
-    fn project<'a, 'b>(
-        &'a self,
-        extensions: &'b http::Extensions,
-    ) -> Result<&'b Self::Output, Self::Error<'a>> {
-        extensions.get().ok_or(UnknownExtension)
+    fn project<'a>(&self, ext: &'a http::Extensions) -> Result<&'a Self::Output, UnknownExtension> {
+        ext.get().ok_or(UnknownExtension)
     }
 }
 
@@ -110,10 +119,7 @@ where
     type Error<'a> = UnknownExtension;
     type Output = T;
 
-    fn project<'a, 'b>(
-        &'a self,
-        request: &'b Request<App>,
-    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, UnknownExtension> {
         self.project(request.extensions())
     }
 }
@@ -122,10 +128,7 @@ impl<App> Project<Request<App>> for Headers {
     type Error<'a> = Infallible;
     type Output = http::HeaderMap;
 
-    fn project<'a, 'b>(
-        &'a self,
-        request: &'b Request<App>,
-    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Infallible> {
         Ok(request.headers())
     }
 }
@@ -138,10 +141,13 @@ impl Project<HeaderMap> for Header {
         &'a self,
         headers: &'b HeaderMap,
     ) -> Result<&'b Self::Output, Self::Error<'a>> {
-        headers
-            .get(&self.name)
-            .map(|value| value.as_bytes())
-            .ok_or_else(|| &self.name)
+        let name = &self.name;
+
+        if let Some(value) = headers.get(name) {
+            Ok(value.as_bytes())
+        } else {
+            Err(name)
+        }
     }
 }
 
@@ -149,10 +155,7 @@ impl<App> Project<Request<App>> for Method {
     type Error<'a> = Infallible;
     type Output = http::Method;
 
-    fn project<'a, 'b>(
-        &'a self,
-        request: &'b Request<App>,
-    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Infallible> {
         Ok(request.method())
     }
 }
@@ -161,7 +164,7 @@ impl Project<http::Uri> for Query {
     type Error<'a> = MissingUriQuery;
     type Output = [u8];
 
-    fn project<'a, 'b>(&'a self, uri: &'b http::Uri) -> Result<&'b Self::Output, Self::Error<'a>> {
+    fn project<'a>(&self, uri: &'a http::Uri) -> Result<&'a Self::Output, MissingUriQuery> {
         uri.query().map(str::as_bytes).ok_or(MissingUriQuery)
     }
 }
@@ -170,11 +173,8 @@ impl<App> Project<Request<App>> for Query {
     type Error<'a> = MissingUriQuery;
     type Output = [u8];
 
-    fn project<'a, 'b>(
-        &'a self,
-        request: &'b Request<App>,
-    ) -> Result<&'b Self::Output, Self::Error<'a>> {
-        <Self as Project<http::Uri>>::project(self, request.uri())
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, MissingUriQuery> {
+        self.project(request.uri())
     }
 }
 
@@ -182,7 +182,7 @@ impl Project<http::Uri> for Path {
     type Error<'a> = Infallible;
     type Output = [u8];
 
-    fn project<'a, 'b>(&'a self, uri: &'b http::Uri) -> Result<&'b Self::Output, Self::Error<'a>> {
+    fn project<'a>(&self, uri: &'a http::Uri) -> Result<&'a Self::Output, Infallible> {
         Ok(uri.path().as_bytes())
     }
 }
@@ -191,11 +191,8 @@ impl<App> Project<Request<App>> for Path {
     type Error<'a> = Infallible;
     type Output = [u8];
 
-    fn project<'a, 'b>(
-        &'a self,
-        request: &'b Request<App>,
-    ) -> Result<&'b Self::Output, Self::Error<'a>> {
-        <Self as Project<http::Uri>>::project(self, request.uri())
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Infallible> {
+        self.project(request.uri())
     }
 }
 
@@ -203,10 +200,7 @@ impl<App> Project<Request<App>> for Uri {
     type Error<'a> = Infallible;
     type Output = http::Uri;
 
-    fn project<'a, 'b>(
-        &'a self,
-        request: &'b Request<App>,
-    ) -> Result<&'b Self::Output, Self::Error<'b>> {
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Infallible> {
         Ok(request.uri())
     }
 }

--- a/via/src/guard/on/project.rs
+++ b/via/src/guard/on/project.rs
@@ -45,8 +45,8 @@ pub struct Uri;
 ///
 /// ```
 /// use std::convert::Infallible;
-/// use via::guard::on::{On, Project};
-/// use via::{Request, guard};
+/// use via::guard::{self, On, Project};
+/// use via::Request;
 ///
 /// pub struct Path;
 ///

--- a/via/src/guard/on/project.rs
+++ b/via/src/guard/on/project.rs
@@ -2,8 +2,10 @@
 
 use std::convert::Infallible;
 
+use http::{HeaderMap, HeaderName};
+
 use crate::Request;
-use crate::guard::error::EmptyQuery;
+use crate::guard::error::MissingUriQuery;
 
 /// Project the request headers.
 pub struct Headers;
@@ -45,82 +47,115 @@ pub struct Uri;
 ///     }
 /// }
 /// ```
+///
+/// [`headers`]: super::headers
+/// [`method`]: super::method
 pub trait Project<Input> {
-    type Error;
+    /// The error type returned when projection fails.
+    type Error<'a>
+    where
+        Self: 'a;
 
     /// The projected value type.
     type Output: ?Sized;
 
     /// Returns a reference to the projected value.
-    fn project<'a>(&self, input: &'a Input) -> Result<&'a Self::Output, Self::Error>;
+    fn project<'a, 'b>(&'a self, input: &'b Input) -> Result<&'b Self::Output, Self::Error<'a>>;
+}
+
+pub(crate) struct Header {
+    pub(super) name: HeaderName,
 }
 
 impl<App> Project<Request<App>> for Headers {
-    type Error = Infallible;
+    type Error<'a> = Infallible;
     type Output = http::HeaderMap;
 
-    #[inline]
-    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+    fn project<'a, 'b>(
+        &'a self,
+        request: &'b Request<App>,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
         Ok(request.headers())
     }
 }
 
+impl Project<HeaderMap> for Header {
+    type Error<'a> = &'a HeaderName;
+    type Output = [u8];
+
+    fn project<'a, 'b>(
+        &'a self,
+        headers: &'b HeaderMap,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+        headers
+            .get(&self.name)
+            .map(|value| value.as_bytes())
+            .ok_or_else(|| &self.name)
+    }
+}
+
 impl<App> Project<Request<App>> for Method {
-    type Error = Infallible;
+    type Error<'a> = Infallible;
     type Output = http::Method;
 
-    #[inline]
-    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+    fn project<'a, 'b>(
+        &'a self,
+        request: &'b Request<App>,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
         Ok(request.method())
     }
 }
 
 impl Project<http::Uri> for Query {
-    type Error = EmptyQuery;
+    type Error<'a> = MissingUriQuery;
     type Output = [u8];
 
-    #[inline]
-    fn project<'a>(&self, uri: &'a http::Uri) -> Result<&'a Self::Output, Self::Error> {
-        uri.query().map(str::as_bytes).ok_or(EmptyQuery)
+    fn project<'a, 'b>(&'a self, uri: &'b http::Uri) -> Result<&'b Self::Output, Self::Error<'a>> {
+        uri.query().map(str::as_bytes).ok_or(MissingUriQuery)
     }
 }
 
 impl<App> Project<Request<App>> for Query {
-    type Error = EmptyQuery;
+    type Error<'a> = MissingUriQuery;
     type Output = [u8];
 
-    #[inline]
-    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
-        self.project(request.uri())
+    fn project<'a, 'b>(
+        &'a self,
+        request: &'b Request<App>,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+        <Self as Project<http::Uri>>::project(self, request.uri())
     }
 }
 
 impl Project<http::Uri> for Path {
-    type Error = Infallible;
+    type Error<'a> = Infallible;
     type Output = [u8];
 
-    #[inline]
-    fn project<'a>(&self, uri: &'a http::Uri) -> Result<&'a Self::Output, Self::Error> {
+    fn project<'a, 'b>(&'a self, uri: &'b http::Uri) -> Result<&'b Self::Output, Self::Error<'a>> {
         Ok(uri.path().as_bytes())
     }
 }
 
 impl<App> Project<Request<App>> for Path {
-    type Error = Infallible;
+    type Error<'a> = Infallible;
     type Output = [u8];
 
-    #[inline]
-    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
-        self.project(request.uri())
+    fn project<'a, 'b>(
+        &'a self,
+        request: &'b Request<App>,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+        <Self as Project<http::Uri>>::project(self, request.uri())
     }
 }
 
 impl<App> Project<Request<App>> for Uri {
-    type Error = Infallible;
+    type Error<'a> = Infallible;
     type Output = http::Uri;
 
-    #[inline]
-    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+    fn project<'a, 'b>(
+        &'a self,
+        request: &'b Request<App>,
+    ) -> Result<&'b Self::Output, Self::Error<'b>> {
         Ok(request.uri())
     }
 }

--- a/via/src/guard/on/project.rs
+++ b/via/src/guard/on/project.rs
@@ -1,11 +1,15 @@
 //! Nameable, built-in projection types.
 
 use std::convert::Infallible;
+use std::marker::PhantomData;
 
 use http::{HeaderMap, HeaderName};
 
 use crate::Request;
-use crate::guard::error::MissingUriQuery;
+use crate::guard::error::{MissingUriQuery, UnknownExtension};
+
+/// Project the request extensions.
+pub struct Extensions;
 
 /// Project the request headers.
 pub struct Headers;
@@ -16,7 +20,7 @@ pub struct Method;
 /// Project the request URI path.
 pub struct Path;
 
-/// Project the request URI query str.
+/// Project the request URI query.
 pub struct Query;
 
 /// Project the request URI.
@@ -63,8 +67,55 @@ pub trait Project<Input> {
     fn project<'a, 'b>(&'a self, input: &'b Input) -> Result<&'b Self::Output, Self::Error<'a>>;
 }
 
+/// Project the request extension of type `T`.
+pub struct Extension<T> {
+    pub(super) _ty: PhantomData<T>,
+}
+
 pub(crate) struct Header {
     pub(super) name: HeaderName,
+}
+
+impl<App> Project<Request<App>> for Extensions {
+    type Error<'a> = Infallible;
+    type Output = http::Extensions;
+
+    fn project<'a, 'b>(
+        &'a self,
+        request: &'b Request<App>,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+        Ok(request.extensions())
+    }
+}
+
+impl<T> Project<http::Extensions> for Extension<T>
+where
+    T: Send + Sync + 'static,
+{
+    type Error<'a> = UnknownExtension;
+    type Output = T;
+
+    fn project<'a, 'b>(
+        &'a self,
+        extensions: &'b http::Extensions,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+        extensions.get().ok_or(UnknownExtension)
+    }
+}
+
+impl<T, App> Project<Request<App>> for Extension<T>
+where
+    T: Send + Sync + 'static,
+{
+    type Error<'a> = UnknownExtension;
+    type Output = T;
+
+    fn project<'a, 'b>(
+        &'a self,
+        request: &'b Request<App>,
+    ) -> Result<&'b Self::Output, Self::Error<'a>> {
+        self.project(request.extensions())
+    }
 }
 
 impl<App> Project<Request<App>> for Headers {

--- a/via/src/guard/on/project.rs
+++ b/via/src/guard/on/project.rs
@@ -1,42 +1,24 @@
-use crate::Request;
+//! Nameable, built-in projection types.
 
-/// A predicate that projects a request's headers before evaluation.
-///
-/// `Headers<T>` adapts a predicate over [`http::HeaderMap`] so that it may be
-/// evaluated directly against a [`Request`].
-///
-/// This is equivalent to calling [`on`] with the request's headers as the
-/// projection target.
-///
-/// # Example
-///
-/// ```
-/// use via::guard::header::media;
-/// use via::guard::{on, header};
-///
-/// let predicate = on::headers(header::accept(media::json()));
-/// ```
+use std::convert::Infallible;
+
+use crate::Request;
+use crate::guard::error::EmptyQuery;
+
+/// Project the request headers.
 pub struct Headers;
 
-/// A predicate that projects a request's method before evaluation.
-///
-/// `Method<T>` adapts a predicate over [`http::Method`] so that it may be
-/// evaluated directly against a [`Request`].
-///
-/// This is equivalent to calling [`on`] with the request's method as the
-/// projection target.
-///
-/// # Example
-///
-/// ```
-/// use http::Method;
-/// use via::guard::method::allow;
-/// use via::guard::{self, on};
-///
-/// let patch_or_put = guard::or((allow(Method::PATCH), allow(Method::PUT)));
-/// let predicate = on::method(patch_or_put);;
-/// ```
+/// Project the request method.
 pub struct Method;
+
+/// Project the request URI path.
+pub struct Path;
+
+/// Project the request URI query str.
+pub struct Query;
+
+/// Project the request URI.
+pub struct Uri;
 
 /// Projects one input type into another.
 ///
@@ -58,33 +40,87 @@ pub struct Method;
 /// impl<App> Project<Request<App>> for Path {
 ///     type Output = str;
 ///
-///     fn project<'a>(&self, request: &'a Request<App>) -> &'a Self::Output {
-///         request.uri().path()
+///     fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+///         Ok(request.uri().path())
 ///     }
 /// }
 /// ```
 pub trait Project<Input> {
-    /// The projected type.
+    type Error;
+
+    /// The projected value type.
     type Output: ?Sized;
 
     /// Returns a reference to the projected value.
-    fn project<'a>(&self, input: &'a Input) -> &'a Self::Output;
+    fn project<'a>(&self, input: &'a Input) -> Result<&'a Self::Output, Self::Error>;
 }
 
 impl<App> Project<Request<App>> for Headers {
+    type Error = Infallible;
     type Output = http::HeaderMap;
 
     #[inline]
-    fn project<'a>(&self, request: &'a Request<App>) -> &'a Self::Output {
-        request.headers()
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+        Ok(request.headers())
     }
 }
 
 impl<App> Project<Request<App>> for Method {
+    type Error = Infallible;
     type Output = http::Method;
 
     #[inline]
-    fn project<'a>(&self, request: &'a Request<App>) -> &'a Self::Output {
-        request.method()
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+        Ok(request.method())
+    }
+}
+
+impl Project<http::Uri> for Query {
+    type Error = EmptyQuery;
+    type Output = [u8];
+
+    #[inline]
+    fn project<'a>(&self, uri: &'a http::Uri) -> Result<&'a Self::Output, Self::Error> {
+        uri.query().map(str::as_bytes).ok_or(EmptyQuery)
+    }
+}
+
+impl<App> Project<Request<App>> for Query {
+    type Error = EmptyQuery;
+    type Output = [u8];
+
+    #[inline]
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+        self.project(request.uri())
+    }
+}
+
+impl Project<http::Uri> for Path {
+    type Error = Infallible;
+    type Output = [u8];
+
+    #[inline]
+    fn project<'a>(&self, uri: &'a http::Uri) -> Result<&'a Self::Output, Self::Error> {
+        Ok(uri.path().as_bytes())
+    }
+}
+
+impl<App> Project<Request<App>> for Path {
+    type Error = Infallible;
+    type Output = [u8];
+
+    #[inline]
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+        self.project(request.uri())
+    }
+}
+
+impl<App> Project<Request<App>> for Uri {
+    type Error = Infallible;
+    type Output = http::Uri;
+
+    #[inline]
+    fn project<'a>(&self, request: &'a Request<App>) -> Result<&'a Self::Output, Self::Error> {
+        Ok(request.uri())
     }
 }

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -192,10 +192,10 @@ pub struct Any;
 ///     // If the request method is safe, cache the response.
 ///     app.middleware(guard::filter(
 ///         on::method(guard::or((
-///             method(Method::GET),
-///             method(Method::HEAD),
-///             method(Method::OPTIONS),
-///             method(Method::TRACE),
+///             method::get(),
+///             method::head(),
+///             method::options(),
+///             method::trace(),
 ///         ))),
 ///         async |request, next| {
 ///             todo!("implement response caching");

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -1,10 +1,7 @@
 use std::convert::Infallible;
 
-/// All of the predicates in self must match the input.
-pub struct And<T>(T);
-
-/// Map a predicate's error to a different type.
-pub struct MapErr<T, F>(T, F);
+use super::error::MapError;
+use crate::Error;
 
 /// Coerce a predicate to a boolean expression and negate it.
 pub struct Not<T>(T);
@@ -12,11 +9,11 @@ pub struct Not<T>(T);
 /// One of the predicates in self must match the input.
 pub struct Or<T>(T);
 
-/// Require a predicate to match if the first matches.
+/// Conditionally execute the second predicate if the first succeeds.
 pub struct When<T, U>(T, U);
 
-/// Match any input.
-pub struct Wildcard;
+/// A predicate that succeeds for any input.
+pub struct Any;
 
 /// An inexpensive comparison operation that can fail with context.
 ///
@@ -232,10 +229,18 @@ pub trait Predicate<Input: ?Sized> {
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>>;
 }
 
+/// Conditionally execute either the second or third predicate based on the
+/// first.
 pub struct IfElse<P, T, E> {
     predicate: P,
     if_true: T,
     or_else: E,
+}
+
+/// Map a predicate's error to a different type.
+pub struct MapErr<T, F> {
+    predicate: T,
+    op: F,
 }
 
 // Macros adapted for our use case from the nom crate:
@@ -309,6 +314,13 @@ macro_rules! impl_or_predicate {
     };
 }
 
+/// Returns a predicate that succeeds for any input.
+pub fn any() -> Any {
+    Any
+}
+
+/// Conditionally execute either the second or third predicate based on the
+/// first.
 pub fn if_else<P, T, E>(predicate: P, if_true: T, or_else: E) -> IfElse<P, T, E> {
     IfElse {
         predicate,
@@ -340,8 +352,8 @@ pub fn if_else<P, T, E>(predicate: P, if_true: T, or_else: E) -> IfElse<P, T, E>
 ///     |_| err!(400, "http version not supported"),
 /// )));
 /// ```
-pub fn map_err<T, F>(predicate: T, map: F) -> MapErr<T, F> {
-    MapErr(predicate, map)
+pub fn map_err<T, F>(predicate: T, op: F) -> MapErr<T, F> {
+    MapErr { predicate, op }
 }
 
 /// Coerce `predicate` to a boolean expression and negate it.
@@ -354,14 +366,9 @@ pub fn or<T>(tuple: T) -> Or<T> {
     Or(tuple)
 }
 
-/// Apply the second predicate when the first matches the input.
+/// Conditionally execute the second predicate if the first succeeds.
 pub fn when<T, U>(first: T, second: U) -> When<T, U> {
     When(first, second)
-}
-
-/// Match any input.
-pub fn wildcard() -> Wildcard {
-    Wildcard
 }
 
 // The maximum length of a tuple is 10.
@@ -388,16 +395,18 @@ where
     }
 }
 
-impl<T, E, F, Input> Predicate<Input> for MapErr<T, F>
+impl<T, F, Input> Predicate<Input> for MapErr<T, F>
 where
     for<'a> T: Predicate<Input> + 'a,
-    for<'a> F: Fn(T::Error<'_>) -> E + Copy + 'a,
+    for<'a> F: Fn(T::Error<'_>) -> Error + Copy + 'a,
     Input: ?Sized,
 {
-    type Error<'a> = E;
+    type Error<'a> = MapError<'a, F, T::Error<'a>>;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
-        self.0.cmp(input).map_err(&self.1)
+        self.predicate
+            .cmp(input)
+            .map_err(|error| MapError::new(&self.op, error))
     }
 }
 
@@ -430,7 +439,7 @@ where
     }
 }
 
-impl<Input> Predicate<Input> for Wildcard
+impl<Input> Predicate<Input> for Any
 where
     Input: ?Sized,
 {

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -232,6 +232,12 @@ pub trait Predicate<Input: ?Sized> {
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>>;
 }
 
+pub struct IfElse<P, T, E> {
+    predicate: P,
+    if_true: T,
+    or_else: E,
+}
+
 // Macros adapted for our use case from the nom crate:
 // https://github.com/rust-bakery/nom/blob/main/src/branch/mod.rs
 
@@ -303,6 +309,14 @@ macro_rules! impl_or_predicate {
     };
 }
 
+pub fn if_else<P, T, E>(predicate: P, if_true: T, or_else: E) -> IfElse<P, T, E> {
+    IfElse {
+        predicate,
+        if_true,
+        or_else,
+    }
+}
+
 /// Map the provided predicate's error to a different type.
 ///
 /// The returned error type must erase the lifetime of the original error. This
@@ -355,6 +369,24 @@ pub fn wildcard() -> Wildcard {
 
 and_impls!(A B C D E F G H I J);
 or_impls!(A B C D E F G H I J);
+
+impl<P, T, E, Input> Predicate<Input> for IfElse<P, T, E>
+where
+    for<'a> P: Predicate<Input> + 'a,
+    for<'a> T: Predicate<Input> + 'a,
+    for<'a> E: Predicate<Input, Error<'a> = T::Error<'a>> + 'a,
+    Input: ?Sized,
+{
+    type Error<'a> = E::Error<'a>;
+
+    fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
+        if self.predicate.cmp(input).is_ok() {
+            self.if_true.cmp(input)
+        } else {
+            self.or_else.cmp(input)
+        }
+    }
+}
 
 impl<T, E, F, Input> Predicate<Input> for MapErr<T, F>
 where

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -175,8 +175,8 @@ pub struct Any;
 ///
 /// To demonstrate this, let's reimplement the [`method::is_safe`] predicate
 /// using combinators rather than [the fn](http::Method::is_safe) defined in
-/// `impl Method` from the [`http`] crate. The [`on`] combinator works great
-/// for this type of projection:
+/// `impl Method` from the [`http`] crate. The [`on`] module provides
+/// combinators that work great for this type of projection:
 ///
 /// ```no_run
 /// use http::Method;
@@ -217,7 +217,7 @@ pub struct Any;
 /// [`HeaderName`]: http::HeaderName
 /// [`Method`]: http::Method
 /// [`method::is_safe`]: crate::guard::method::is_safe
-/// [`on`]: fn@crate::guard::on
+/// [`on`]: mod@crate::guard::on
 pub trait Predicate<Input: ?Sized> {
     /// The error type returned if the predicate fails.
     type Error<'a>

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use super::error::MapError;
+use super::error::ErrorThunk;
 use crate::Error;
 
 /// Coerce a predicate to a boolean expression and negate it.
@@ -236,13 +236,46 @@ pub struct IfElse<P, T, E> {
     or_else: E,
 }
 
-/// Map a predicate's error to a different type.
-pub struct MapErr<T, F> {
+/// Lazily convert predicate errors into [`Error`].
+///
+/// Unlike ordinary error mapping, this combinator does not eagerly construct a
+/// framework error when predicate evaluation fails. Instead, it stores the
+/// predicate error together with a conversion function. The conversion happens
+/// only if the guard error is later converted into [`Error`].
+///
+/// This keeps synchronous guard evaluation allocation-free while still
+/// allowing contextual errors to produce rich framework responses.
+///
+/// The returned error type must erase the lifetime of the original error. This
+/// combinator is particularlly useful when using a closure as a top-level
+/// predicate that must return an `Error` type that can be converted to a
+/// [`via::Error`](crate::Error).
+///
+/// # Example
+///
+/// ```
+/// use http::Version;
+/// use via::{Request, guard};
+///
+/// // Create a new application.
+/// let mut app = via::app(());
+///
+/// // Only support request made with HTTP versions >= 1.1.
+/// app.middleware(guard::barrier(guard::into_error(
+///     |request: &Request| request.version() > Version::HTTP_10,
+///     |_| via::err!(400, "http version not supported"),
+/// )));
+/// ```
+pub struct IntoError<T, F> {
     predicate: T,
     op: F,
 }
 
-/// If the predicate fails, error with a reference to `E`.
+/// Attach a trusted error context to a predicate.
+///
+/// The returned error borrows `E`. Guard middleware converts that borrow into
+/// an owned `Error` before returning a future. The borrow returned in the
+/// `Err` discriminant of `cmp` only exists for a couple of nanoseconds.
 pub struct OkOr<T, E> {
     predicate: T,
     error: E,
@@ -334,31 +367,25 @@ pub fn if_else<P, T, E>(predicate: P, if_true: T, or_else: E) -> IfElse<P, T, E>
     }
 }
 
-/// Map the provided predicate's error to a different type.
-///
-/// The returned error type must erase the lifetime of the original error. This
-/// combinator is particularlly useful when using a closure as a top-level
-/// predicate that must return an `Error` type that can be converted to a
-/// [`via::Error`](crate::Error).
+/// Lazily convert an error from `predicate` into an [`Error`].
 ///
 /// # Example
 ///
 /// ```
 /// use http::Version;
-/// use via::guard::{self, map_err};
-/// use via::{err, Request};
+/// use via::{Request, guard};
 ///
 /// // Create a new application.
 /// let mut app = via::app(());
 ///
 /// // Only support request made with HTTP versions >= 1.1.
-/// app.middleware(guard::barrier(map_err(
+/// app.middleware(guard::barrier(guard::into_error(
 ///     |request: &Request| request.version() > Version::HTTP_10,
-///     |_| err!(400, "http version not supported"),
+///     |_| via::err!(400, "http version not supported"),
 /// )));
 /// ```
-pub fn map_err<T, F>(predicate: T, op: F) -> MapErr<T, F> {
-    MapErr { predicate, op }
+pub fn into_error<T, F>(predicate: T, op: F) -> IntoError<T, F> {
+    IntoError { predicate, op }
 }
 
 /// Coerce `predicate` to a boolean expression and negate it.
@@ -366,7 +393,11 @@ pub fn not<T>(predicate: T) -> Not<T> {
     Not(predicate)
 }
 
-/// If `predicate` fails, error with a reference to `E`.
+/// Attach trusted error context `E` to `predicate`.
+///
+/// The returned error borrows `E`. Guard middleware converts that borrow into
+/// an owned `Error` before returning a future. The borrow returned in the
+/// `Err` discriminant of `cmp` only exists for a couple of nanoseconds.
 pub fn ok_or<T, E>(predicate: T, error: E) -> OkOr<T, E> {
     OkOr { predicate, error }
 }
@@ -416,18 +447,18 @@ where
     }
 }
 
-impl<T, F, Input> Predicate<Input> for MapErr<T, F>
+impl<T, F, Input> Predicate<Input> for IntoError<T, F>
 where
     for<'a> T: Predicate<Input> + 'a,
     for<'a> F: Fn(T::Error<'_>) -> Error + Copy + 'a,
     Input: ?Sized,
 {
-    type Error<'a> = MapError<'a, F, T::Error<'a>>;
+    type Error<'a> = ErrorThunk<'a, F, T::Error<'a>>;
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
         self.predicate
             .cmp(input)
-            .map_err(|error| MapError::new(&self.op, error))
+            .map_err(|error| ErrorThunk::new(&self.op, error))
     }
 }
 

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -181,8 +181,7 @@ pub struct Any;
 /// ```no_run
 /// use http::Method;
 /// use std::process::ExitCode;
-/// use via::guard::method::allow;
-/// use via::guard::{self, on};
+/// use via::guard::{self, method, on};
 /// use via::{Error, Request, Server};
 ///
 /// #[tokio::main]
@@ -193,10 +192,10 @@ pub struct Any;
 ///     // If the request method is safe, cache the response.
 ///     app.middleware(guard::filter(
 ///         on::method(guard::or((
-///             allow(Method::GET),
-///             allow(Method::HEAD),
-///             allow(Method::OPTIONS),
-///             allow(Method::TRACE),
+///             method(Method::GET),
+///             method(Method::HEAD),
+///             method(Method::OPTIONS),
+///             method(Method::TRACE),
 ///         ))),
 ///         async |request, next| {
 ///             todo!("implement response caching");

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -243,6 +243,12 @@ pub struct MapErr<T, F> {
     op: F,
 }
 
+/// If the predicate fails, error with a reference to `E`.
+pub struct OkOr<T, E> {
+    predicate: T,
+    error: E,
+}
+
 // Macros adapted for our use case from the nom crate:
 // https://github.com/rust-bakery/nom/blob/main/src/branch/mod.rs
 
@@ -361,6 +367,11 @@ pub fn not<T>(predicate: T) -> Not<T> {
     Not(predicate)
 }
 
+/// If `predicate` fails, error with a reference to `E`.
+pub fn ok_or<T, E>(predicate: T, error: E) -> OkOr<T, E> {
+    OkOr { predicate, error }
+}
+
 /// One of the predicates in `tuple` must match the input.
 pub fn or<T>(tuple: T) -> Or<T> {
     Or(tuple)
@@ -376,6 +387,17 @@ pub fn when<T, U>(first: T, second: U) -> When<T, U> {
 
 and_impls!(A B C D E F G H I J);
 or_impls!(A B C D E F G H I J);
+
+impl<Input> Predicate<Input> for Any
+where
+    Input: ?Sized,
+{
+    type Error<'a> = Infallible;
+
+    fn cmp<'a>(&'a self, _: &Input) -> Result<(), Self::Error<'a>> {
+        Ok(())
+    }
+}
 
 impl<P, T, E, Input> Predicate<Input> for IfElse<P, T, E>
 where
@@ -426,6 +448,19 @@ where
     }
 }
 
+impl<T, E, Input> Predicate<Input> for OkOr<T, E>
+where
+    for<'a> T: Predicate<Input> + 'a,
+    for<'a> E: 'a,
+    Input: ?Sized,
+{
+    type Error<'a> = &'a E;
+
+    fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
+        self.predicate.cmp(input).map_err(|_| &self.error)
+    }
+}
+
 impl<T, U, Input> Predicate<Input> for When<T, U>
 where
     for<'a> T: Predicate<Input> + 'a,
@@ -436,17 +471,6 @@ where
 
     fn cmp<'a>(&'a self, input: &Input) -> Result<(), Self::Error<'a>> {
         self.0.cmp(input).map_or(Ok(()), |_| self.1.cmp(input))
-    }
-}
-
-impl<Input> Predicate<Input> for Any
-where
-    Input: ?Sized,
-{
-    type Error<'a> = Infallible;
-
-    fn cmp<'a>(&'a self, _: &Input) -> Result<(), Self::Error<'a>> {
-        Ok(())
     }
 }
 

--- a/via/src/middleware.rs
+++ b/via/src/middleware.rs
@@ -177,8 +177,8 @@ pub type Result<T = Response> = std::result::Result<T, Error>;
 ///
 /// ```no_run
 /// use std::process::ExitCode;
-/// use via::guard::{header::media, method};
-/// use via::{Error, Server, cookies, guard, rescue};
+/// use via::guard::{self, media, method};
+/// use via::{Error, Server, cookies, rescue};
 ///
 /// mod session {
 ///     // Implementations elided...

--- a/via/src/middleware.rs
+++ b/via/src/middleware.rs
@@ -240,7 +240,7 @@ pub type Result<T = Response> = std::result::Result<T, Error>;
 ///     // restore a user's session to our JSON API if they cannot
 ///     // send and receive JSON.
 ///     api.middleware(guard::flat_map(
-///         guard::content!(media::json),
+///         guard::content!(media::json()),
 ///         session::restore(),
 ///     ));
 ///

--- a/via/src/ws/error.rs
+++ b/via/src/ws/error.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::ControlFlow;
 
 use crate::error::Error;
-use crate::guard::header::DenyHeader;
+use crate::guard::error::InvalidHeader;
 
 #[cfg(feature = "tokio-tungstenite")]
 pub use tungstenite::error::Error as WebSocketError;
@@ -68,8 +68,8 @@ impl Display for UpgradeError {
     }
 }
 
-impl From<DenyHeader<'_>> for UpgradeError {
-    fn from(error: DenyHeader<'_>) -> Self {
+impl From<InvalidHeader<'_>> for UpgradeError {
+    fn from(error: InvalidHeader<'_>) -> Self {
         match error.name().as_str() {
             "sec-websocket-version" => UpgradeError::SecWebsocketVersion,
             "connection" => UpgradeError::UpgradeRequired,

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -16,7 +16,7 @@ use tokio_websockets::WebSocketStream;
 use super::run::RunTask;
 use super::util::{Base64EncodedDigest, sha1};
 use super::{Channel, Request};
-use crate::guard::bytes::{self, CaseSensitive, Contains};
+use crate::guard::bytes::{Contains, Tag, TagNoCase, Trim};
 use crate::guard::{Header, Predicate, header};
 use crate::server::IoStream;
 use crate::ws::error::UpgradeError;
@@ -24,9 +24,11 @@ use crate::{BoxFuture, Error, Middleware, Next, Response, ResultExt};
 
 const DEFAULT_FRAME_SIZE: usize = 16384; // 16KB
 
+type HasToken = Contains<Trim<Tag>>;
+
 pub struct Ws<T> {
     listener: Arc<Listener<T>>,
-    guard: (Header<CaseSensitive>, Header<Contains>, Header<Contains>),
+    guard: (Header<TagNoCase>, Header<HasToken>, Header<HasToken>),
 }
 
 pub(super) struct Listener<T> {
@@ -113,6 +115,8 @@ where
 
 impl<T> Ws<T> {
     pub(super) fn new(listener: T) -> Self {
+        use crate::guard::bytes::{contains, tag, tag_no_case, trim};
+
         Self {
             listener: Arc::new(Listener {
                 handle: listener,
@@ -123,9 +127,9 @@ impl<T> Ws<T> {
                 },
             }),
             guard: (
-                header(h::SEC_WEBSOCKET_VERSION, bytes::case_sensitive(b"13")),
-                header(h::CONNECTION, bytes::contains(bytes::tag(b"upgrade"), b',')),
-                header(h::UPGRADE, bytes::contains(bytes::tag(b"websocket"), b',')),
+                header(h::SEC_WEBSOCKET_VERSION, tag_no_case(b"13")),
+                header(h::CONNECTION, contains(trim(tag(b"upgrade")), b',')),
+                header(h::UPGRADE, contains(trim(tag(b"websocket")), b',')),
             ),
         }
     }

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -16,8 +16,8 @@ use tokio_websockets::WebSocketStream;
 use super::run::RunTask;
 use super::util::{Base64EncodedDigest, sha1};
 use super::{Channel, Request};
-use crate::guard::header::{CaseSensitive, Contains, Header};
-use crate::guard::{Predicate, header};
+use crate::guard::bytes::{self, CaseSensitive, Contains};
+use crate::guard::{Header, Predicate, header};
 use crate::server::IoStream;
 use crate::ws::error::UpgradeError;
 use crate::{BoxFuture, Error, Middleware, Next, Response, ResultExt};
@@ -123,9 +123,9 @@ impl<T> Ws<T> {
                 },
             }),
             guard: (
-                header(h::SEC_WEBSOCKET_VERSION, header::case_sensitive(b"13")),
-                header(h::CONNECTION, header::contains(header::tag(b"upgrade"))),
-                header(h::UPGRADE, header::contains(header::tag(b"websocket"))),
+                header(h::SEC_WEBSOCKET_VERSION, bytes::case_sensitive(b"13")),
+                header(h::CONNECTION, bytes::contains(bytes::tag(b"upgrade"), b',')),
+                header(h::UPGRADE, bytes::contains(bytes::tag(b"websocket"), b',')),
             ),
         }
     }

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -16,7 +16,7 @@ use tokio_websockets::WebSocketStream;
 use super::run::RunTask;
 use super::util::{Base64EncodedDigest, sha1};
 use super::{Channel, Request};
-use crate::guard::bytes::{Contains, Tag, TagNoCase, Trim};
+use crate::guard::bytes::{CaseSensitive, Contains, Tag, Trim};
 use crate::guard::{Header, Predicate, header};
 use crate::server::IoStream;
 use crate::ws::error::UpgradeError;
@@ -28,7 +28,7 @@ type HasToken = Contains<Trim<Tag>>;
 
 pub struct Ws<T> {
     listener: Arc<Listener<T>>,
-    guard: (Header<TagNoCase>, Header<HasToken>, Header<HasToken>),
+    guard: (Header<CaseSensitive>, Header<HasToken>, Header<HasToken>),
 }
 
 pub(super) struct Listener<T> {
@@ -115,7 +115,7 @@ where
 
 impl<T> Ws<T> {
     pub(super) fn new(listener: T) -> Self {
-        use crate::guard::bytes::{contains, tag, tag_no_case, trim};
+        use crate::guard::bytes::{case_sensitive, contains, tag, trim};
 
         Self {
             listener: Arc::new(Listener {
@@ -127,7 +127,7 @@ impl<T> Ws<T> {
                 },
             }),
             guard: (
-                header(h::SEC_WEBSOCKET_VERSION, tag_no_case(b"13")),
+                header(h::SEC_WEBSOCKET_VERSION, case_sensitive(b"13")),
                 header(h::CONNECTION, contains(trim(tag(b"upgrade")), b',')),
                 header(h::UPGRADE, contains(trim(tag(b"websocket")), b',')),
             ),


### PR DESCRIPTION
Introduces an `if_else` combinator to the guard algebra. Also optimizes the `content!` macro to be as efficient as possible.