### PR TITLE
feat(via): request decoration with before middleware

### DIFF
--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -42,7 +42,7 @@ tokio-websockets = [
 
 # Internal
 
-__test = ["fs", "ring", "tokio-tungstenite", "zeroize/serde"]
+__test = ["cookie/signed", "fs", "ring", "tokio-tungstenite", "zeroize/serde"]
 
 [dependencies]
 aws-lc-rs = { version = "1", optional = true }

--- a/via/src/before.rs
+++ b/via/src/before.rs
@@ -1,0 +1,207 @@
+use std::ops::ControlFlow;
+
+use crate::error::Catch;
+use crate::{BoxFuture, Middleware, Next, Request};
+
+/// A middleware adapter that decorates a request before delegation.
+///
+/// `Before` runs a synchronous decorator function against the incoming
+/// [`Request`] before invoking another middleware.
+///
+/// The decorator may mutate the request in place to derive, normalize, or cache
+/// request state for downstream middleware. This is useful for work such as
+/// restoring session identity, parsing cookies, or initializing extensions from
+/// request metadata.
+///
+/// Decorators return [`Catch`], which determines how decoration failures affect
+/// the pipeline:
+///
+/// - [`ControlFlow::Break`] terminates execution and returns the error.
+/// - [`ControlFlow::Continue`] logs the error, skips the wrapped middleware,
+///   and continues with [`Next`].
+///
+/// See [`before`] for a convenient constructor.
+pub struct Before<T, U> {
+    decorator: T,
+    middleware: U,
+}
+
+/// Creates middleware that decorates a request before invoking another
+/// middleware.
+///
+/// The `decorator` receives a mutable reference to the request and may mutate
+/// it in place before the wrapped middleware executes.
+///
+/// If decoration succeeds, the wrapped middleware is called. If decoration
+/// fails with [`ControlFlow::Break`], the error is returned immediately. If it
+/// fails with [`ControlFlow::Continue`], the error is logged and the request is
+/// forwarded to the next middleware without calling the wrapped middleware.
+///
+/// # Example
+///
+/// Restore an identity token from the session cookie before conditionally
+/// refreshing the active user session.
+///
+/// ```no_run
+/// mod session {
+///     // Implementations elided...
+///     # use via::error::Catch;
+///     # use via::guard::Predicate;
+///     # use via::{Middleware, Request};
+///     #
+///     # use super::Unicorn;
+///     #
+///     # pub const COOKIE: &str = "via-session";
+///     #
+///     # pub fn needs_verified() -> fn(&Request<Unicorn>) -> bool { |_| true }
+///     # pub fn restore(_: &mut Request<Unicorn>) -> Result<(), Catch> { todo!() }
+///     # pub fn verify() -> impl Middleware<Unicorn> + 'static {
+///     #     via::middleware(|request, next| next.call(request))
+///     # }
+/// }
+///
+/// use cookie::Key;
+/// use std::process::ExitCode;
+/// use via::guard::{self, media, method};
+/// use via::{Error, Server, cookies, rescue};
+///
+/// struct Unicorn {
+///     secret: Key,
+/// }
+///
+/// #[tokio::main]
+/// async fn main() -> Result<ExitCode, Error> {
+///     let mut app = via::app(Unicorn {
+///         secret: Key::generate(),
+///         // secret: std::env::var("VIA_SECRET_KEY")
+///         //     .map(|secret| secret.as_bytes().try_into())
+///         //     .expect("missing required env var: VIA_SECRET_KEY")
+///         //     .expect("unexpected end of input while parsing VIA_SECRET_KEY"),
+///     });
+///
+///     // The /api namespace.
+///     let mut api = app.route("api");
+///
+///     // If an error occurs, respond with JSON.
+///     api.middleware(rescue(|sanitizer| sanitizer.use_json()));
+///
+///     // Parse and track changes that are made to the session cookie.
+///     api.middleware(cookies([session::COOKIE]));
+///
+///     // Content negotiation and authentication guards.
+///     api.middleware(guard::flat_map(
+///         // Confirm that the client speaks JSON.
+///         guard::content!(media::json()),
+///         // Then, initialize the active user session.
+///         via::before(
+///             // Restore an identity token from the session cookie.
+///             session::restore,
+///             // If the request is read only or the active users account has
+///             // been confirmed to exist in the past hour, skip verification.
+///             //
+///             // Such an optimization is sound so long as your app is the
+///             // authoritative source of truth for the session and you
+///             // properly end websocket sessions when a user deletes their
+///             // account.
+///             guard::filter(
+///                 guard::or((method::is_mutation(), session::needs_verified())),
+///                 session::verify(),
+///             ),
+///         ),
+///     ));
+///
+///     // Serve the application at http://localhost:8080/.
+///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///}
+/// ```
+///
+/// <details>
+/// <summary>Click here to view an example <code>mod session</code>.</summary>
+///
+/// ```rust
+/// # use cookie::Key;
+/// #
+/// # struct Unicorn {
+/// #     secret: Key,
+/// # }
+/// #
+/// # impl Unicorn {
+/// #     fn secret(&self) -> &Key { &self.secret }
+/// # }
+/// #
+/// use via::error::{Catch, Error, Propagate};
+/// use via::{Middleware, Request, err};
+///
+/// pub const COOKIE: &str = "via-session";
+///
+/// #[derive(Clone, Copy, PartialEq)]
+/// pub struct Identity([u8; 16]);
+///
+/// impl std::str::FromStr for Identity {
+///     type Err = Error;
+///
+///     fn from_str(input: &str) -> Result<Self, Self::Err> {
+///          todo!()
+///     }
+/// }
+///
+/// /// Restore the active user session from the session cookie.
+/// pub fn restore(request: &mut Request<Unicorn>) -> Result<(), Catch> {
+///     // Authenticate the signed cookie jar using the signing secret
+///     // stored in the application (Unicorn).
+///     let jar = {
+///         let secret = request.app().secret();
+///         request.cookies().signed(secret)
+///     };
+///
+///     let token = jar
+///         // Retrieve the session cookie from the signed cookie jar.
+///         .get(COOKIE)
+///         // If the session cookie *is not* present, return a generic,
+///         // `401 Unauthorized` error.
+///         .ok_or_else(|| err!(401, "unauthorized."))
+///         // If the session cookie *is* present, parse an identity token
+///         // from the base64 encoded string in its value.
+///         .and_then(|cookie| cookie.value().parse::<Identity>())
+///         // If an error occurred, continue to the next middleware.
+///         // The user may be trying to create an account or login.
+///         .or_continue()?;
+///
+///     // Insert the identity token into the request extensions.
+///     request.extensions_mut().insert(token);
+///
+///     // The request was decorated successfully.
+///     Ok(())
+/// }
+///
+/// /// Returns a middleware that verifies the active user account.
+/// pub fn verify() -> impl Middleware<Unicorn> + 'static {
+///     via::middleware(|request, next| {
+///         todo!("verify that the active user has an account.")
+///     })
+/// }
+/// ```
+/// </details>
+pub fn before<T, U>(decorator: T, middleware: U) -> Before<T, U> {
+    Before {
+        decorator,
+        middleware,
+    }
+}
+
+impl<T, U, App> Middleware<App> for Before<T, U>
+where
+    T: Fn(&mut Request<App>) -> Result<(), Catch> + Copy + Send + Sync,
+    U: Middleware<App>,
+{
+    fn call(&self, mut request: Request<App>, next: Next<App>) -> BoxFuture {
+        match (self.decorator)(&mut request) {
+            Ok(_) => self.middleware.call(request, next),
+            Err(ControlFlow::Break(error)) => Box::pin(async { Err(error) }),
+            Err(ControlFlow::Continue(error)) => {
+                log!(warn(before = 0), "{}", &error);
+                next.call(request)
+            }
+        }
+    }
+}

--- a/via/src/error/catch.rs
+++ b/via/src/error/catch.rs
@@ -1,0 +1,175 @@
+use std::ops::ControlFlow;
+
+use super::Error;
+
+/// Indicates how a recoverable error should affect contextual control flow.
+///
+/// `Catch` is returned from fallible operations whose errors may be handled in
+/// more than one way. Rather than deciding globally whether an error is fatal,
+/// `Catch` lets the caller describe whether the error should break out of the
+/// current context or continue from the next recoverable boundary.
+///
+/// The meaning of [`ControlFlow::Break`] and [`ControlFlow::Continue`] depends
+/// on where the `Catch` is handled:
+///
+/// - In [`before`] middleware, `Break` rejects the request while `Continue`
+///   skips the wrapped middleware and resumes execution with [`Next`].
+///
+/// - In a WebSocket listener passed to [`ws`], `Break` closes the connection
+///   while `Continue` keeps the connection open and restarts the listener.
+///
+/// - In other adapters, `Break` and `Continue` may map to whatever boundary the
+///   adapter defines as fatal or recoverable.
+///
+/// See [`Propagate`] for convenience methods that convert common result-like
+/// data structures into a result with an error type of `Catch`.
+///
+/// [`Next`]: crate::Next
+/// [`before`]: fn@crate::before
+/// [`ws`]: fn@crate::ws
+pub type Catch = ControlFlow<Error, Error>;
+
+/// Convert result-like data structures into contextual control flow.
+///
+/// `Propagate` provides convenience methods for indicating whether an error
+/// is considered fatal or recoverable.
+///
+/// The context in which a [`Catch`] occurs determines the significance of each
+/// discriminant in [`ControlFlow`].
+///
+/// # Example
+///
+/// When returned from a request decorator in [`before`] middleware, the
+/// `Continue` variant skips the wrapped middleware and resumes execution with
+/// [`Next`], while the `Break` variant immediately rejects the request with
+/// the contained error.
+///
+/// ```
+/// use via::error::{Catch, Propagate};
+/// use via::{Request, err};
+/// #
+/// # #[derive(Clone, Copy, PartialEq)]
+/// # struct Identity([u8; 16]);
+/// #
+/// # impl std::str::FromStr for Identity {
+/// #     type Err = via::Error;
+/// #
+/// #     fn from_str(input: &str) -> Result<Self, Self::Err> {
+/// #          todo!()
+/// #     }
+/// # }
+///
+/// pub fn restore(request: &mut Request) -> Result<(), Catch> {
+///     let token = request
+///         .cookies()
+///         .get("via-session")
+///         .ok_or_else(|| err!(401, "unauthorized."))
+///         .and_then(|cookie| cookie.value().parse::<Identity>())
+///         .or_continue()?;
+///     //   ^^^^^^^^^^^
+///     //
+///     // Continue to the next middleware.
+///     // The user may be trying to create an account or login.
+///     //
+///     // Insert the identity token into the request extensions.
+///     request.extensions_mut().insert(token);
+///     //
+///     // Request decorated successfully.
+///     Ok(())
+/// }
+/// ```
+///
+/// When returned from a web socket listener passed to [`ws`], the `Continue`
+/// discriminant keeps the web socket connection open and restarts the listener
+/// where the `Break` variant immediately closes the connection.
+///
+/// ```
+/// use std::ops::ControlFlow;
+///
+/// use via::error::Propagate;
+/// use via::ws::{self, Channel, Request};
+/// #
+/// # #[derive(Clone, Copy)]
+/// # pub struct Identity([u8; 16]);
+/// #
+/// # pub trait Session {
+/// #     fn session(&self) -> Option<&Identity>;
+/// # }
+/// #
+/// # impl Session for Request {
+/// #     fn session(&self) -> Option<&Identity> { todo!() }
+/// # }
+///
+/// pub async fn echo(mut channel: Channel, request: Request) -> ws::Result {
+///     let Some(_me) = request.session().copied() else {
+///         return via::err!(401, "unauthorized.").or_break();
+///         //                                     ^^^^^^^^
+///         // If the request is not authenticated, close the connection.
+///     };
+///
+///     while let Some(message) = channel.recv().await {
+///         if message.is_binary() || message.is_text() {
+///             let text = message.to_text().or_continue()?;
+///             //                           ^^^^^^^^^^^
+///             // Invalid UTF-8 rejects this frame and restarts the receive loop.
+///             //
+///             // Valid UTF-8 is echoed back to the client.
+///             channel.send(text).await?;
+///             //                      ^
+///             // Send errors unconditionally close the connection as they
+///             // imply a dropped receiver.
+///         } else if message.is_close() {
+///             break; // A close opcode gracefully terminates the listener.
+///         }
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// [`Next`]: crate::Next
+/// [`before`]: fn@crate::before
+/// [`ws`]: fn@crate::ws
+pub trait Propagate {
+    /// The successful output of the operation.
+    type Output;
+
+    /// Marks a fallible operation as fatal.
+    ///
+    /// The exact behavior depends on where the resulting [`Catch`] is handled.
+    fn or_break(self) -> Result<Self::Output, Catch>;
+
+    /// Marks a fallible operation as recoverable.
+    ///
+    /// The exact behavior depends on where the resulting [`Catch`] is handled.
+    fn or_continue(self) -> Result<Self::Output, Catch>;
+}
+
+impl Propagate for Error {
+    type Output = ();
+
+    fn or_break(self) -> Result<Self::Output, Catch> {
+        Err(ControlFlow::Break(self))
+    }
+
+    fn or_continue(self) -> Result<Self::Output, Catch> {
+        Err(ControlFlow::Continue(self))
+    }
+}
+
+impl<T, E> Propagate for Result<T, E>
+where
+    Error: From<E>,
+{
+    type Output = T;
+
+    #[inline]
+    fn or_break(self) -> Result<Self::Output, Catch> {
+        self.map_err(|error| ControlFlow::Break(error.into()))
+    }
+
+    #[inline]
+    fn or_continue(self) -> Result<Self::Output, Catch> {
+        self.map_err(|error| ControlFlow::Continue(error.into()))
+    }
+}

--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -1,6 +1,7 @@
 //! Error handling.
 //!
 
+mod catch;
 mod macros;
 mod rescue;
 mod result;
@@ -14,6 +15,7 @@ use std::borrow::Cow;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io::{self, Error as IoError};
 
+pub use catch::{Catch, Propagate};
 pub use rescue::{Rescue, Sanitizer, rescue};
 pub use result::ResultExt;
 pub(crate) use server::ServerError;

--- a/via/src/lib.rs
+++ b/via/src/lib.rs
@@ -45,6 +45,20 @@
 //! proud of.
 //!
 
+macro_rules! log {
+    ($level:tt($name:ident = $indent:expr), $fmt:literal $($arg:tt)*) => {
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "{:indent$}{}({}): {}",
+            "",
+            stringify!($level),
+            stringify!($name),
+            format_args!($fmt $($arg)*),
+            indent = $indent * 2,
+        );
+    };
+}
+
 pub mod error;
 pub mod guard;
 pub mod request;
@@ -55,6 +69,7 @@ pub mod router;
 pub mod ws;
 
 mod app;
+mod before;
 mod cookies;
 mod middleware;
 mod next;
@@ -63,6 +78,7 @@ mod server;
 mod util;
 
 pub use app::{Shared, Via, app};
+pub use before::{Before, before};
 pub use cookies::{Cookies, cookies};
 pub use error::{Error, ResultExt, rescue};
 pub use middleware::{BoxFuture, Middleware, Result, middleware};

--- a/via/src/server/accept.rs
+++ b/via/src/server/accept.rs
@@ -21,18 +21,6 @@ use crate::error::ServerError;
 #[cfg(any(feature = "native-tls", feature = "rustls-23"))]
 use super::tls::{Alpn, NegotiateAlpn};
 
-macro_rules! log {
-    ($level:tt($reason:tt), $fmt:literal $($arg:tt)*) => {
-        #[cfg(debug_assertions)]
-        eprintln!(
-            "{}({}): {}",
-            stringify!($level),
-            stringify!($reason),
-            format_args!($fmt $($arg)*)
-        );
-    };
-}
-
 macro_rules! serve_unless_cancelled {
     ($cancellation:ident, $connection:ident) => {
         tokio::select! {
@@ -81,7 +69,7 @@ where
                 Ok(stream) => stream,
                 Err(error) => {
                     // Print the error message to stderr in debug builds.
-                    log!(error(accept), "{}", error);
+                    log!(error(accept = 0), "{}", error);
 
                     // Exit with a corresponding error exit code or continue
                     // on EMFILE for POSIX systems.
@@ -192,7 +180,7 @@ where
 
 async fn drain_connections(immediate: bool, mut connections: JoinSet<Result<(), ServerError>>) {
     log!(
-        info(gc),
+        info(gc = 0),
         "joining {} inflight connections...",
         connections.len()
     );
@@ -205,10 +193,10 @@ async fn drain_connections(immediate: bool, mut connections: JoinSet<Result<(), 
         match result {
             Ok(Ok(_)) => {}
             Err(error) => {
-                log!(error(connection), "{}", &error);
+                log!(error(gc = 1), "(connection) -> {}", &error);
             }
             Ok(Err(error)) => {
-                log!(error(service), "{}", &error);
+                log!(error(gc = 1), "(service) -> {}", &error);
             }
         }
 
@@ -243,6 +231,7 @@ where
         .with_upgrades();
 
     serve_unless_cancelled!(cancellation, connection);
+
     Ok(())
 }
 

--- a/via/src/ws/error.rs
+++ b/via/src/ws/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 use std::ops::ControlFlow;
 
-use crate::error::Error;
+use crate::error::{Catch, Error};
 use crate::guard::error::InvalidHeader;
 
 #[cfg(feature = "tokio-tungstenite")]
@@ -10,14 +10,7 @@ pub use tungstenite::error::Error as WebSocketError;
 #[cfg(all(feature = "tokio-websockets", not(feature = "tokio-tungstenite")))]
 pub use tokio_websockets::error::Error as WebSocketError;
 
-pub type Result<T = ()> = std::result::Result<T, ControlFlow<Error, Error>>;
-
-pub trait ResultExt {
-    type Output;
-
-    fn or_close(self) -> Result<Self::Output>;
-    fn or_reconnect(self) -> Result<Self::Output>;
-}
+pub type Result<T = ()> = std::result::Result<T, Catch>;
 
 #[derive(Debug)]
 pub enum UpgradeError {
@@ -28,11 +21,11 @@ pub enum UpgradeError {
     Other,
 }
 
-pub fn already_closed() -> ControlFlow<Error, Error> {
+pub fn already_closed() -> Catch {
     ControlFlow::Break(Error::from_source(Box::new(WebSocketError::AlreadyClosed)))
 }
 
-pub fn rescue(error: WebSocketError) -> ControlFlow<Error, Error> {
+pub fn rescue(error: WebSocketError) -> Catch {
     use std::io::ErrorKind;
 
     if let WebSocketError::Io(io) = &error
@@ -76,34 +69,5 @@ impl From<InvalidHeader<'_>> for UpgradeError {
             "upgrade" => UpgradeError::UnknownUpgradeType,
             _ => UpgradeError::Other,
         }
-    }
-}
-
-impl ResultExt for Error {
-    type Output = ();
-
-    fn or_close(self) -> Result<Self::Output> {
-        Err(ControlFlow::Break(self))
-    }
-
-    fn or_reconnect(self) -> Result<Self::Output> {
-        Err(ControlFlow::Continue(self))
-    }
-}
-
-impl<T, E> ResultExt for std::result::Result<T, E>
-where
-    Error: From<E>,
-{
-    type Output = T;
-
-    #[inline]
-    fn or_close(self) -> Result<Self::Output> {
-        self.map_err(|error| ControlFlow::Break(error.into()))
-    }
-
-    #[inline]
-    fn or_reconnect(self) -> Result<Self::Output> {
-        self.map_err(|error| ControlFlow::Continue(error.into()))
     }
 }

--- a/via/src/ws/mod.rs
+++ b/via/src/ws/mod.rs
@@ -7,19 +7,6 @@ compile_error!("either \"aws-lc-rs\" or \"ring\" must be enabled to use the ws m
 #[cfg(all(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
 compile_error!("features \"tokio-tungstenite\" and \"tokio-websockets\" are mutually exclusive.");
 
-macro_rules! log {
-    ($level:tt($indent:expr), $fmt:literal $($arg:tt)*) => {
-        #[cfg(debug_assertions)]
-        eprintln!(
-            "{:indent$}{}(ws): {}",
-            "",
-            stringify!($level),
-            format_args!($fmt $($arg)*),
-            indent = $indent
-        );
-    };
-}
-
 mod channel;
 mod error;
 mod request;
@@ -28,7 +15,7 @@ mod upgrade;
 mod util;
 
 pub use channel::*;
-pub use error::{Result, ResultExt};
+pub use error::Result;
 pub use request::Request;
 pub use upgrade::Ws;
 

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -89,6 +89,18 @@ impl Drop for Facade {
     }
 }
 
+macro_rules! indent {
+    ($i:ident = $value:expr) => {
+        #[cfg(debug_assertions)]
+        {
+            $i = $value;
+        }
+    };
+    ($i:ident) => {
+        indent!($i = $i + 1);
+    };
+}
+
 impl Future for Facade {
     type Output = super::Result;
 
@@ -107,7 +119,8 @@ impl Future for Facade {
 
             match &mut self.state {
                 IoState::Receive => {
-                    log!(info(i), "state = receive");
+                    log!(info(ws = i), "state = receive");
+                    indent!(i);
 
                     // Confirm that the listener can receive the next message.
                     if self.rendezvous.has_capacity()? {
@@ -120,10 +133,10 @@ impl Future for Facade {
 
                             // If send fails, the channel is disconnected.
                             self.rendezvous.try_send(received)?;
-                            log!(info(i + 2), "inbound message forwarded to listener.");
+                            log!(info(ws = i), "inbound message forwarded to listener.");
                         }
                     } else {
-                        log!(info(i + 2), "listener is busy.");
+                        log!(info(ws = i), "listener is busy.");
                     }
 
                     // The listener will probably register an additional wake.
@@ -133,27 +146,31 @@ impl Future for Facade {
                     }
 
                     if let Some(sent) = self.rendezvous.try_recv()? {
-                        log!(info(i + 2), "outbound message received from listener.");
+                        log!(info(ws = i), "outbound message received from listener.");
+                        indent!(i);
+
                         self.state = IoState::Send(sent);
                     } else {
-                        log!(info(i + 2), "waiting for something interesting to happen.");
+                        log!(info(ws = i), "waiting for something interesting to happen.");
                         return Poll::Pending;
                     }
                 }
 
                 state @ IoState::Send(_) => {
-                    log!(info(i), "state = send");
+                    log!(info(ws = i), "state = send");
+                    indent!(i);
 
                     let mut sink = Pin::new(stream);
 
                     if sink.as_mut().poll_ready(cx).map_err(rescue)?.is_pending() {
-                        log!(info(i + 2), "waiting for i/o to become available.");
+                        log!(info(ws = i), "waiting for i/o to become available.");
                         return Poll::Pending;
                     }
 
                     if let IoState::Send(message) = mem::replace(state, IoState::Flush) {
                         sink.as_mut().start_send(message).map_err(rescue)?;
-                        log!(info(i + 2), "outbound message accepted by i/o.");
+                        log!(info(ws = i), "outbound message accepted by i/o.");
+                        indent!(i);
                     } else {
                         // We are in an invalid state. This can be interpreted
                         // as a signal that the risk of re-entrance is elevated
@@ -163,23 +180,19 @@ impl Future for Facade {
                 }
 
                 IoState::Flush => {
-                    log!(info(i), "state = flush");
+                    log!(info(ws = i), "state = flush");
+                    indent!(i);
 
                     if Pin::new(stream).poll_flush(cx).map_err(rescue)?.is_ready() {
-                        log!(info(i + 2), "outbound message sent successfully.");
+                        log!(info(ws = i), "outbound message sent successfully.");
                         self.state = IoState::Receive;
                         cx.waker().wake_by_ref();
                     } else {
-                        log!(info(i + 2), "waiting for flush to complete.");
+                        log!(info(ws = i), "waiting for flush to complete.");
                     }
 
                     return Poll::Pending;
                 }
-            }
-
-            #[cfg(debug_assertions)]
-            {
-                i += 4;
             }
         }
     }
@@ -247,14 +260,14 @@ where
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
             Poll::Ready(Err(ControlFlow::Break(error))) => {
-                log!(error(0), "{}", &error);
+                log!(error(ws = 0), "{}", &error);
                 Poll::Ready(Err(error))
             }
             Poll::Ready(Err(ControlFlow::Continue(error))) => {
                 #[cfg(not(debug_assertions))]
                 let _ = error;
 
-                log!(warn(0), "{}", &error);
+                log!(warn(ws = 1), "{}", &error);
 
                 this.reconnect();
                 context.waker().wake_by_ref();

--- a/via/src/ws/upgrade.rs
+++ b/via/src/ws/upgrade.rs
@@ -109,7 +109,7 @@ where
         #[cfg(not(debug_assertions))]
         let _ = error;
 
-        log!(error(0), "{}", error);
+        log!(error(ws = 0), "{}", error);
     }
 }
 


### PR DESCRIPTION
Introduces a request decorator API backed by the higher-order middleware `Before`.

**Note:**

This PR introduces a small breaking change. `Before` supports continuing on error if the error is considered recoverable by the decorator function. As a result, the web socket error type and `ResultExt` trait now use a common API shared with `before`. To upgrade, simply change `or_reconnect ~> or_continue`, `or_close ~> or_break`, and `use via::ws::ResultExt; ~> use via::error::Propagate;` .

---

`Before` allows users to synchronously mutate the request before delegating to some other middleware. This makes it easy to "decorate" a request with additional metadata before it is passed to the next middleware in the chain. Before takes a second argument for a middleware delegate. This makes it easy to include request decoration as a step in a composition of request guards while also supporting standalone decorates with `Continue`.

```rust
use uuid::Uuid;
use via::error::Catch;
use via::{Request, Server};

fn set_request_id(request: &mut Request) -> Result<(), Catch> {
    request.extensions_mut().insert(Uuid::new_v4());
    Ok(())
}

#[tokio::main]
async fn main() -> via::Result<ExitCode> {
    let mut app = via::app(());

    // Insert a request id into the request extensions, then continue.
    app.middleware(via::before(set_request_id, Continue));

    // Start listening at http://localhost:8080 for incoming requests.
    Server::new(app).listen(("127.0.0.1", 8080)).await
}
```

Taking a second argument for `middleware` rather than naively delegating to `next` in `Before` supports powerful compositions that collapses the middleware cost of many discrete preconditions into a single middleware for a given layer. 

For example, sync request validation can be combined with auth session restoration and verification. Forming a natural boundary where protocol invariants transition to application invariants.

```rust
mod database;
mod routes;
mod util;

use cookie::Key;
use std::process::ExitCode;
use via::guard::{self, media, method};
use via::{Error, Server, cookies, rescue};

use database::Database;
use util::session;

type Request = via::Request<Unicorn>;
type Next = via::Next<Unicorn>;

struct Unicorn {
    database: Database,
    secret: Key,
}

#[tokio::main]
async fn main() -> Result<ExitCode, Error> {
    let mut app = via::app(Unicorn {
        database: Database::new()?,
        secret: Key::generate(),
        // secret: std::env::var("VIA_SECRET_KEY")
        //     .map(|secret| secret.as_bytes().try_into())
        //     .expect("missing required env var: VIA_SECRET_KEY")
        //     .expect("unexpected end of input while parsing VIA_SECRET_KEY"),
    });

    // The /api namespace.
    let mut api = app.route("api");

    // If an error occurs, respond with JSON.
    api.middleware(rescue(|sanitizer| sanitizer.use_json()));

    // Parse and track changes that are made to the session cookie.
    api.middleware(cookies([session::COOKIE]));

    // Content negotiation and authentication guards.
    api.middleware(guard::flat_map(
        // Confirm that the client speaks JSON.
        guard::content!(media::json()),
        // Then, initialize the active user session.
        via::before(
            // Restore an identity token from the session cookie.
            session::restore,
            // If the request is read only or the session was verified in the
            // past hour, skip verifying that the user still has an account.
            //
            // This is safe so long as your app is the authoritative source of
            // truth for the session and you properly end websocket sessions if
            // the user deletes their account.
            guard::filter(
                guard::or((method::is_mutation(), session::needs_verified())),
                session::verify(),
            ),
        ),
    ));

    // Continue defining routes in the API namespace.

    // Start listening at http://localhost:8080 for incoming requests.
    Server::new(app).listen(("127.0.0.1", 8080)).await
}
```

