### PR TITLE
feat(via): Route::scope returns self

### DIFF
--- a/via/src/router/route.rs
+++ b/via/src/router/route.rs
@@ -316,11 +316,14 @@ impl<'a, App> Route<'a, App> {
         Route(self.0.route(path))
     }
 
-    /// Consumes self by calling the provided closure with a mutable reference
-    /// to self.
+    /// Takes ownership of self and then calls `scope` with a mutable ref to
+    /// self.
     ///
-    pub fn scope(mut self, scope: impl FnOnce(&mut Self)) {
+    /// This is particularly useful when you want to attach middleware to a
+    /// route before assigning it a terminal middleware.
+    pub fn scope(mut self, scope: impl FnOnce(&mut Self)) -> Self {
         scope(&mut self);
+        self
     }
 
     /// Defines how the route should respond when it is visited.


### PR DESCRIPTION
This PR updates `Route::scope` to return self. This makes it easy to attach middleware to a route prior to assigning it a terminal middleware without having to bind a variable to the route.