### PR TITLE
chore(via): generate rest scopes with resource!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "3"
-members = ["via", "via-macros", "via-router", "examples"]
+members = ["examples", "via", "via-macros", "via-router"]

--- a/via-macros/Cargo.toml
+++ b/via-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "via-macros"
 version = "0.1.0"
 edition = "2024"
-authors = ["Zachary Golba <zachary.golba@postlight.com>"]
+authors = ["Zakari Papa <pino@hey.com>"]
 license = "MIT OR Apache-2.0"
 description = "A fast and flexible http router."
 homepage = "https://github.com/via-rs/via"

--- a/via-macros/Cargo.toml
+++ b/via-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Zakari Papa <pino@hey.com>"]
 license = "MIT OR Apache-2.0"

--- a/via-macros/src/lib.rs
+++ b/via-macros/src/lib.rs
@@ -1,1 +1,2 @@
 mod guard;
+mod resource;

--- a/via-macros/src/resource.rs
+++ b/via-macros/src/resource.rs
@@ -1,0 +1,817 @@
+/// Generate traditional REST scopes for a resource module.
+///
+/// ```rust
+/// via::resource!(app = Unicorn);
+/// ```
+///
+/// This macro emits up to two public functions in the current module:
+///
+/// ```rust
+/// pub fn collection() -> impl via::Middleware<Unicorn> + 'static
+/// pub fn member() -> impl via::Middleware<Unicorn> + 'static
+/// ```
+///
+/// Path routing determines where a request belongs in the application tree.
+/// The middleware returned by these functions run after path routing and
+/// dispatch the request to a terminal middleware that corresponds to the
+/// request method (or "verb").
+///
+/// <div class="warning">
+/// The corresponding action functions must be visible from the call-site of
+/// the <code>resource!</code> macro.
+/// </div>
+///
+/// ```text
+///    Collection
+/// -----------------
+///   GET  -> index
+///   POST -> create
+///
+///      Member
+/// -----------------
+/// GET    -> show
+/// PATCH  -> update
+/// DELETE -> destroy
+/// ```
+///
+/// ## Arguments
+///
+/// The only required argument is: `app`.
+///
+/// ```rust
+/// via::resource!(app = Unicorn);
+/// ```
+///
+/// It is used to generate scopes that return middleware that is generic over
+/// your specific application type.
+///
+/// For example, `via::resource!(app = ());` generates:
+///
+/// ```rust
+/// impl via::Middleware<()>
+/// ```
+///
+/// The remaining arguments are optional and can be used to modify the behavior
+/// of the middleware returned by each REST scope. They all take an optional
+/// value that controls the scopes or actions to which they apply.
+///
+/// - `exhaustive` instructs the generated middleware to error with a
+///   `405 Method Not Allowed` response if the request method is not supported.
+///
+/// - `guard` specifies that all scopes, a specific scope, or set of scopes and
+///   / or actions take a `predicate` factory function as an argument.
+///
+/// - `only` is used to omit specific actions or scopes in the generated
+///   output. if a scope does not have actions it is not emitted.
+///
+/// ### Permutations
+///
+/// ```rust
+/// // Generate `collection` and `member` scopes.
+/// via::resource!(app = Unicorn);
+///
+/// // Only generate the `collection` scope.
+/// via::resource!(app = Unicorn, only = collection);
+///
+/// // Only generate the `member` scope.
+/// via::resource!(app = Unicorn, only = member);
+///
+/// // Generate the `collection` scope with a single action: `create`.
+/// via::resource!(app = Unicorn, only = create);
+///
+/// // Omit the `create` action from the generated scopes.
+/// via::resource!(app = Unicorn, only = [index, member]);
+///
+/// // Both scopes take a `predicate` factory function as an argument.
+/// via::resource!(app = Unicorn, guard);
+///
+/// // Only the `collection` scope takes a `predicate` argument.
+/// via::resource!(app = Unicorn, guard = collection);
+///
+/// // Both the `collection` and `member` scope take a `predicate` argument
+/// // but it doesn't apply to the `create` action.
+/// via::resource!(app = Unicorn, guard = [index, member]);
+///
+/// // Any request to a generated scope with unsupported method will `405`.
+/// via::resource!(app = Unicorn, exhaustive);
+///
+/// // Request to the `collection` scope with unsupported method will `405`.
+/// via::resource!(app = Unicorn, exhaustive = collection);
+///
+/// // Request to the `member` scope with unsupported method will `405`.
+/// via::resource!(app = Unicorn, exhaustive = member);
+///
+/// // Generate the `collection` and `member` scope. Exclude `create` from the
+/// // `collection` scope and only apply the guard predicate factory to the
+/// // `index` and `destroy` actions. Requests to either scope with an
+/// // unsupported method will `405`.
+/// via::resource!(
+///     app = Unicorn,
+///     only = [index, member],
+///     guard = [index, destroy],
+///     exhaustive,
+/// );
+/// ```
+#[macro_export]
+macro_rules! resource {
+    (app = $app:ty $(, $($tokens:tt)*)?) => {
+        $crate::__resource_parse! {
+            ($app)
+            [all]
+            [none]
+            [none]
+            $($($tokens)*)?
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_parse {
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_emit!(($app) [$($only)*] [$($guard)*] [$($exhaustive)*]);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*], $($rest:tt)*) => {
+        $crate::__resource_parse!(($app) [$($only)*] [$($guard)*] [$($exhaustive)*] $($rest)*);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] only = collection $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [collection] [$($guard)*] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] only = member $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [member] [$($guard)*] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] only = [$($action:ident),* $(,)?] $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [actions $($action),*] [$($guard)*] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] only = $action:ident $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [actions $action] [$($guard)*] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] guard $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [all] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] guard = collection $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [collection] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] guard = member $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [member] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] guard = [$($action:ident),* $(,)?] $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [actions $($action),*] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] guard = $action:ident $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [actions $action] [$($exhaustive)*] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] exhaustive $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [$($guard)*] [all] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] exhaustive = collection $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [$($guard)*] [collection] $($($rest)*)?);
+    };
+
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*] exhaustive = member $(, $($rest:tt)*)?) => {
+        $crate::__resource_parse!(($app) [$($only)*] [$($guard)*] [member] $($($rest)*)?);
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_emit {
+    (($app:ty) [$($only:tt)*] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_from_only!(($app) [$($only)*] [$($guard)*] [$($exhaustive)*]);
+        $crate::__resource_member_from_only!(($app) [$($only)*] [$($guard)*] [$($exhaustive)*]);
+    };
+}
+
+// Only Scan (Collection)
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_from_only {
+    (($app:ty) [all] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_from_flags!(($app) true true [$($guard)*] [$($exhaustive)*]);
+    };
+
+    (($app:ty) [collection] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_from_flags!(($app) true true [$($guard)*] [$($exhaustive)*]);
+    };
+
+    (($app:ty) [member] [$($guard:tt)*] [$($exhaustive:tt)*]) => {};
+
+    (($app:ty) [actions $($actions:ident),*] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_only_scan! {
+            ($app)
+            [$($guard)*]
+            [$($exhaustive)*]
+            [false]
+            [false];
+            $($actions),*
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_only_scan {
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$index:tt] [$create:tt];) => {
+        $crate::__resource_collection_from_flags!(($app) $index $create [$($guard)*] [$($exhaustive)*]);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$index:tt] [$create:tt]; collection $(, $rest:ident)*) => {
+        $crate::__resource_collection_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [true] [true]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$index:tt] [$create:tt]; member $(, $rest:ident)*) => {
+        $crate::__resource_collection_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [$index] [$create]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$index:tt] [$create:tt]; index $(, $rest:ident)*) => {
+        $crate::__resource_collection_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [true] [$create]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$index:tt] [$create:tt]; create $(, $rest:ident)*) => {
+        $crate::__resource_collection_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [$index] [true]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$index:tt] [$create:tt]; $head:ident $(, $rest:ident)*) => {
+        $crate::__resource_collection_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [$index] [$create]; $($rest),*);
+    };
+}
+
+// Only Scan (Member)
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_from_only {
+    (($app:ty) [all] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_from_flags!(($app) true true true [$($guard)*] [$($exhaustive)*]);
+    };
+
+    (($app:ty) [member] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_from_flags!(($app) true true true [$($guard)*] [$($exhaustive)*]);
+    };
+
+    (($app:ty) [collection] [$($guard:tt)*] [$($exhaustive:tt)*]) => {};
+
+    (($app:ty) [actions $($actions:ident),*] [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_only_scan! {
+            ($app)
+            [$($guard)*]
+            [$($exhaustive)*]
+            [false]
+            [false]
+            [false];
+            $($actions),*
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_only_scan {
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$show:tt] [$update:tt] [$destroy:tt];) => {
+        $crate::__resource_member_from_flags!(($app) $show $update $destroy [$($guard)*] [$($exhaustive)*]);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$show:tt] [$update:tt] [$destroy:tt]; member $(, $rest:ident)*) => {
+        $crate::__resource_member_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [true] [true] [true]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$show:tt] [$update:tt] [$destroy:tt]; collection $(, $rest:ident)*) => {
+        $crate::__resource_member_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [$show] [$update] [$destroy]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$show:tt] [$update:tt] [$destroy:tt]; show $(, $rest:ident)*) => {
+        $crate::__resource_member_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [true] [$update] [$destroy]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$show:tt] [$update:tt] [$destroy:tt]; update $(, $rest:ident)*) => {
+        $crate::__resource_member_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [$show] [true] [$destroy]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$show:tt] [$update:tt] [$destroy:tt]; destroy $(, $rest:ident)*) => {
+        $crate::__resource_member_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [$show] [$update] [true]; $($rest),*);
+    };
+
+    (($app:ty) [$($guard:tt)*] [$($exhaustive:tt)*] [$show:tt] [$update:tt] [$destroy:tt]; $head:ident $(, $rest:ident)*) => {
+        $crate::__resource_member_only_scan!(($app) [$($guard)*] [$($exhaustive)*] [$show] [$update] [$destroy]; $($rest),*);
+    };
+}
+
+// With or Without a Predicate?
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_from_flags {
+    (($app:ty) false false [$($guard:tt)*] [$($exhaustive:tt)*]) => {};
+
+    (($app:ty) $index:tt $create:tt [none] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_unguarded!(($app) $index $create [$($exhaustive)*]);
+    };
+
+    (($app:ty) $index:tt $create:tt [member] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_unguarded!(($app) $index $create [$($exhaustive)*]);
+    };
+
+    (($app:ty) $index:tt $create:tt [all] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_guarded!(($app) $index $create [all] [$($exhaustive)*]);
+    };
+
+    (($app:ty) $index:tt $create:tt [collection] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_guarded!(($app) $index $create [collection] [$($exhaustive)*]);
+    };
+
+    (($app:ty) $index:tt $create:tt [actions $($actions:ident),*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_collection_guard_scan! {
+            ($app)
+            $index
+            $create
+            [actions $($actions),*]
+            [$($exhaustive)*]
+            [false];
+            $($actions),*
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_guard_scan {
+    (($app:ty) $index:tt $create:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt];) => {
+        $crate::__resource_collection_guard_choice!(
+            ($app)
+            $index
+            $create
+            [$($guard)*]
+            [$($exhaustive)*]
+            [$guarded]
+        );
+    };
+
+    (($app:ty) true $create:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; index $(, $rest:ident)*) => {
+        $crate::__resource_collection_guard_scan!(
+            ($app) true $create [$($guard)*] [$($exhaustive)*] [true]; $($rest),*
+        );
+    };
+
+    (($app:ty) $index:tt true [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; create $(, $rest:ident)*) => {
+        $crate::__resource_collection_guard_scan!(
+            ($app) $index true [$($guard)*] [$($exhaustive)*] [true]; $($rest),*
+        );
+    };
+
+    (($app:ty) $index:tt $create:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; collection $(, $rest:ident)*) => {
+        $crate::__resource_collection_guard_scan!(
+            ($app) $index $create [$($guard)*] [$($exhaustive)*] [true]; $($rest),*
+        );
+    };
+
+    (($app:ty) $index:tt $create:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; $head:ident $(, $rest:ident)*) => {
+        $crate::__resource_collection_guard_scan!(
+            ($app) $index $create [$($guard)*] [$($exhaustive)*] [$guarded]; $($rest),*
+        );
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_guard_choice {
+    (($app:ty) $index:tt $create:tt [$($guard:tt)*] [$($exhaustive:tt)*] [true]) => {
+        $crate::__resource_collection_guarded!(
+            ($app)
+            $index
+            $create
+            [$($guard)*]
+            [$($exhaustive)*]
+        );
+    };
+
+    (($app:ty) $index:tt $create:tt [$($guard:tt)*] [$($exhaustive:tt)*] [false]) => {
+        $crate::__resource_collection_unguarded!(
+            ($app)
+            $index
+            $create
+            [$($exhaustive)*]
+        );
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_from_flags {
+    (($app:ty) false false false [$($guard:tt)*] [$($exhaustive:tt)*]) => {};
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [none] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_unguarded!(($app) $show $update $destroy [$($exhaustive)*]);
+    };
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [collection] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_unguarded!(($app) $show $update $destroy [$($exhaustive)*]);
+    };
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [all] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_guarded!(($app) $show $update $destroy [all] [$($exhaustive)*]);
+    };
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [member] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_guarded!(($app) $show $update $destroy [member] [$($exhaustive)*]);
+    };
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [actions $($actions:ident),*] [$($exhaustive:tt)*]) => {
+        $crate::__resource_member_guard_scan! {
+            ($app)
+            $show
+            $update
+            $destroy
+            [actions $($actions),*]
+            [$($exhaustive)*]
+            [false];
+            $($actions),*
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_guard_scan {
+    (($app:ty) $show:tt $update:tt $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt];) => {
+        $crate::__resource_member_guard_choice!(
+            ($app)
+            $show
+            $update
+            $destroy
+            [$($guard)*]
+            [$($exhaustive)*]
+            [$guarded]
+        );
+    };
+
+    (($app:ty) true $update:tt $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; show $(, $rest:ident)*) => {
+        $crate::__resource_member_guard_scan!(
+            ($app) true $update $destroy [$($guard)*] [$($exhaustive)*] [true]; $($rest),*
+        );
+    };
+
+    (($app:ty) $show:tt true $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; update $(, $rest:ident)*) => {
+        $crate::__resource_member_guard_scan!(
+            ($app) $show true $destroy [$($guard)*] [$($exhaustive)*] [true]; $($rest),*
+        );
+    };
+
+    (($app:ty) $show:tt $update:tt true [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; destroy $(, $rest:ident)*) => {
+        $crate::__resource_member_guard_scan!(
+            ($app) $show $update true [$($guard)*] [$($exhaustive)*] [true]; $($rest),*
+        );
+    };
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; member $(, $rest:ident)*) => {
+        $crate::__resource_member_guard_scan!(
+            ($app) $show $update $destroy [$($guard)*] [$($exhaustive)*] [true]; $($rest),*
+        );
+    };
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*] [$guarded:tt]; $head:ident $(, $rest:ident)*) => {
+        $crate::__resource_member_guard_scan!(
+            ($app) $show $update $destroy [$($guard)*] [$($exhaustive)*] [$guarded]; $($rest),*
+        );
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_guard_choice {
+    (($app:ty) $show:tt $update:tt $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*] [true]) => {
+        $crate::__resource_member_guarded!(
+            ($app)
+            $show
+            $update
+            $destroy
+            [$($guard)*]
+            [$($exhaustive)*]
+        );
+    };
+
+    (($app:ty) $show:tt $update:tt $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*] [false]) => {
+        $crate::__resource_member_unguarded!(
+            ($app)
+            $show
+            $update
+            $destroy
+            [$($exhaustive)*]
+        );
+    };
+}
+
+// Scopes
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_unguarded {
+    (($app:ty) $index:tt $create:tt [$($exhaustive:tt)*]) => {
+        pub fn collection() -> impl via::Middleware<$app> + 'static {
+            $crate::__resource_collection_switch!(unguarded $index $create [$($exhaustive)*])
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_guarded {
+    (($app:ty) $index:tt $create:tt [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        pub fn collection<T>(predicate: impl Fn() -> T) -> impl via::Middleware<$app> + 'static
+        where
+            T: via::guard::Predicate<via::Request<$app>> + Send + Sync + 'static,
+            for<'a> T::Error<'a>: Into<via::Error>,
+        {
+            $crate::__resource_collection_switch!(guarded predicate [$($guard)*] $index $create [$($exhaustive)*])
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_unguarded {
+    (($app:ty) $show:tt $update:tt $destroy:tt [$($exhaustive:tt)*]) => {
+        pub fn member() -> impl via::Middleware<$app> + 'static {
+            $crate::__resource_member_switch!(unguarded $show $update $destroy [$($exhaustive)*])
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_guarded {
+    (($app:ty) $show:tt $update:tt $destroy:tt [$($guard:tt)*] [$($exhaustive:tt)*]) => {
+        pub fn member<T>(predicate: impl Fn() -> T) -> impl via::Middleware<$app> + 'static
+        where
+            T: via::guard::Predicate<via::Request<$app>> + Send + Sync + 'static,
+            for<'a> T::Error<'a>: Into<via::Error>,
+        {
+            $crate::__resource_member_switch!(guarded predicate [$($guard)*] $show $update $destroy [$($exhaustive)*])
+        }
+    };
+}
+
+// Switches
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_collection_switch {
+    (unguarded true true [$($exhaustive:tt)*]) => {{
+        let switch = via::get(index).post(create);
+        $crate::__resource_maybe_deny!(collection [$($exhaustive)*] switch)
+    }};
+
+    (unguarded true false [$($exhaustive:tt)*]) => {{
+        let switch = via::get(index);
+        $crate::__resource_maybe_deny!(collection [$($exhaustive)*] switch)
+    }};
+
+    (unguarded false true [$($exhaustive:tt)*]) => {{
+        let switch = via::post(create);
+        $crate::__resource_maybe_deny!(collection [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] true true [$($exhaustive:tt)*]) => {{
+        let switch = via::get($crate::__resource_guard_action!($predicate [$($guard)*] index))
+            .post($crate::__resource_guard_action!($predicate [$($guard)*] create));
+
+        $crate::__resource_maybe_deny!(collection [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] true false [$($exhaustive:tt)*]) => {{
+        let switch = via::get($crate::__resource_guard_action!($predicate [$($guard)*] index));
+        $crate::__resource_maybe_deny!(collection [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] false true [$($exhaustive:tt)*]) => {{
+        let switch = via::post($crate::__resource_guard_action!($predicate [$($guard)*] create));
+        $crate::__resource_maybe_deny!(collection [$($exhaustive)*] switch)
+    }};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_member_switch {
+    (unguarded true true true [$($exhaustive:tt)*]) => {{
+        let switch = via::get(show).patch(update).delete(destroy);
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (unguarded true true false [$($exhaustive:tt)*]) => {{
+        let switch = via::get(show).patch(update);
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (unguarded true false true [$($exhaustive:tt)*]) => {{
+        let switch = via::get(show).delete(destroy);
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (unguarded false true true [$($exhaustive:tt)*]) => {{
+        let switch = via::patch(update).delete(destroy);
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (unguarded true false false [$($exhaustive:tt)*]) => {{
+        let switch = via::get(show);
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (unguarded false true false [$($exhaustive:tt)*]) => {{
+        let switch = via::patch(update);
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (unguarded false false true [$($exhaustive:tt)*]) => {{
+        let switch = via::delete(destroy);
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] true true true [$($exhaustive:tt)*]) => {{
+        let switch = via::get($crate::__resource_guard_action!($predicate [$($guard)*] show))
+            .patch($crate::__resource_guard_action!($predicate [$($guard)*] update))
+            .delete($crate::__resource_guard_action!($predicate [$($guard)*] destroy));
+
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] true true false [$($exhaustive:tt)*]) => {{
+        let switch = via::get($crate::__resource_guard_action!($predicate [$($guard)*] show))
+            .patch($crate::__resource_guard_action!($predicate [$($guard)*] update));
+
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] true false true [$($exhaustive:tt)*]) => {{
+        let switch = via::get($crate::__resource_guard_action!($predicate [$($guard)*] show))
+            .delete($crate::__resource_guard_action!($predicate [$($guard)*] destroy));
+
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] false true true [$($exhaustive:tt)*]) => {{
+        let switch = via::patch($crate::__resource_guard_action!($predicate [$($guard)*] update))
+            .delete($crate::__resource_guard_action!($predicate [$($guard)*] destroy));
+
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] true false false [$($exhaustive:tt)*]) => {{
+        let switch = via::get($crate::__resource_guard_action!($predicate [$($guard)*] show));
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] false true false [$($exhaustive:tt)*]) => {{
+        let switch = via::patch($crate::__resource_guard_action!($predicate [$($guard)*] update));
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+
+    (guarded $predicate:ident [$($guard:tt)*] false false true [$($exhaustive:tt)*]) => {{
+        let switch = via::delete($crate::__resource_guard_action!($predicate [$($guard)*] destroy));
+        $crate::__resource_maybe_deny!(member [$($exhaustive)*] switch)
+    }};
+}
+
+// Guards
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_guard_action {
+    ($predicate:ident [all] $action:ident) => {
+        via::guard::flat_map($predicate(), $action)
+    };
+
+    ($predicate:ident [collection] index) => {
+        via::guard::flat_map($predicate(), index)
+    };
+
+    ($predicate:ident [collection] create) => {
+        via::guard::flat_map($predicate(), create)
+    };
+
+    ($predicate:ident [member] show) => {
+        via::guard::flat_map($predicate(), show)
+    };
+
+    ($predicate:ident [member] update) => {
+        via::guard::flat_map($predicate(), update)
+    };
+
+    ($predicate:ident [member] destroy) => {
+        via::guard::flat_map($predicate(), destroy)
+    };
+
+    ($predicate:ident [actions $($actions:ident),*] $action:ident) => {
+        $crate::__resource_guard_action_list!($predicate $action; $($actions),*)
+    };
+
+    ($predicate:ident [$($guard:tt)*] $action:ident) => {
+        $action
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_guard_action_list {
+    ($predicate:ident $action:ident;) => {
+        $action
+    };
+
+    ($predicate:ident index; collection $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), index)
+    };
+
+    ($predicate:ident create; collection $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), create)
+    };
+
+    ($predicate:ident show; collection $(, $rest:ident)*) => {
+        $crate::__resource_guard_action_list!($predicate show; $($rest),*)
+    };
+
+    ($predicate:ident update; collection $(, $rest:ident)*) => {
+        $crate::__resource_guard_action_list!($predicate update; $($rest),*)
+    };
+
+    ($predicate:ident destroy; collection $(, $rest:ident)*) => {
+        $crate::__resource_guard_action_list!($predicate destroy; $($rest),*)
+    };
+
+    ($predicate:ident index; member $(, $rest:ident)*) => {
+        $crate::__resource_guard_action_list!($predicate index; $($rest),*)
+    };
+
+    ($predicate:ident create; member $(, $rest:ident)*) => {
+        $crate::__resource_guard_action_list!($predicate create; $($rest),*)
+    };
+
+    ($predicate:ident show; member $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), show)
+    };
+
+    ($predicate:ident update; member $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), update)
+    };
+
+    ($predicate:ident destroy; member $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), destroy)
+    };
+
+    ($predicate:ident index; index $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), index)
+    };
+
+    ($predicate:ident create; create $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), create)
+    };
+
+    ($predicate:ident show; show $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), show)
+    };
+
+    ($predicate:ident update; update $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), update)
+    };
+
+    ($predicate:ident destroy; destroy $(, $rest:ident)*) => {
+        via::guard::flat_map($predicate(), destroy)
+    };
+
+    ($predicate:ident $action:ident; $head:ident $(, $rest:ident)*) => {
+        $crate::__resource_guard_action_list!($predicate $action; $($rest),*)
+    };
+}
+
+// Exhuastive
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __resource_maybe_deny {
+    ($scope:ident [all] $switch:ident) => {
+        $switch.or_deny()
+    };
+
+    (collection [collection] $switch:ident) => {
+        $switch.or_deny()
+    };
+
+    (member [member] $switch:ident) => {
+        $switch.or_deny()
+    };
+
+    ($scope:ident [$($exhaustive:tt)*] $switch:ident) => {
+        $switch
+    };
+}

--- a/via-router/Cargo.toml
+++ b/via-router/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "via-router"
 version = "3.0.0-beta.35"
-authors = ["Zachary Golba <zachary.golba@postlight.com>"]
+authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A fast and flexible http router."

--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1"
 smallvec = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tokio-websockets = { version = "0.13", features = ["ring", "server"], optional = true }
-via-macros = { path = "../via-macros", version = "0.1" }
+via-macros = { path = "../via-macros", version = "0.2" }
 via-router = { path = "../via-router", version = "3.0.0-beta.35" }
 zeroize = "1"
 

--- a/via/src/lib.rs
+++ b/via/src/lib.rs
@@ -77,6 +77,8 @@ mod next;
 mod server;
 mod util;
 
+pub use via_macros::resource;
+
 pub use app::{Shared, Via, app};
 pub use before::{Before, before};
 pub use cookies::{Cookies, cookies};

--- a/via/src/router/mod.rs
+++ b/via/src/router/mod.rs
@@ -15,6 +15,49 @@ pub(crate) struct Router<App> {
     tree: via_router::Router<Arc<dyn Middleware<App>>>,
 }
 
+/// Returns a partially applied function that attaches `middleware` to a route.
+///
+/// This is intended to be used with [`Route::map`], allowing middleware to be
+/// composed into a route without having to write a closure.
+///
+/// # Example
+///
+/// ```
+/// // Create a new application.
+/// let mut app = via::app(());
+///
+/// // Define the /api namespace
+/// let mut path = app.push("/api");
+///
+/// // Define the /api/auth namespace.
+/// path.route("/auth", via::post(login).delete(logout))
+///     //                        ^^^^^         ^^^^^^
+///     //
+///     // The `login` and `logout` middleware both terminate the
+///     // request.
+///     //
+///     // Therefore, `authenticate` can safely be applied after
+///     // them without changing their behavior.
+///     .map(via::router::apply(authenticate))
+///     // Requests to "/api/auth/me" or any descendant of "/auth"
+///     // require an authenticated user.
+///     .route("/me", via::get(me));
+/// #
+/// # async fn authenticate(_: via::Request, _: via::Next) -> via::Result { unimplemented!() }
+/// # async fn login(_: via::Request, _: via::Next) -> via::Result { unimplemented!() }
+/// # async fn logout(_: via::Request, _: via::Next) -> via::Result { unimplemented!() }
+/// # async fn me(_: via::Request, _: via::Next) -> via::Result { unimplemented!() }
+/// ```
+pub fn apply<T, App>(middleware: T) -> impl for<'a> FnOnce(Route<'a, App>) -> Route<'a, App>
+where
+    T: Middleware<App> + 'static,
+{
+    |mut path| {
+        path.middleware(middleware);
+        path
+    }
+}
+
 impl<App> Router<App> {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
Introduces a `resource!` macro that generates traditional REST scopes for a module that contains well-known REST actions. Builds on top of #603 to finalize the core router DSL.

## Usage

```rust
// routes/users.rs
via::resource!(app = Unicorn, guard = [index, member]);
//                            ^^^^^^^^^^^^^^^^^^^^^^^
//
// Creating an account does not require authentication.

use via::{Response, deny};
use crate::{Next, Request, Unicorn};

async fn index(_: Request, _: Next) -> via::Result {
    deny!(500, "todo!")
}

async fn create(_: Request, _: Next) -> via::Result {
    deny!(500, "todo!")
}

async fn show(_: Request, _: Next) -> via::Result {
    deny!(500, "todo!")
}

async fn update(_: Request, _: Next) -> via::Result {
    deny!(500, "todo!")
}

async fn destroy(_: Request, _: Next) -> via::Result {
    deny!(500, "todo!")
}
```

Guard predicates are not applied at the call-site to keep the trust boundary visible where routes are defined. 

```rust
// main.rs
use routes::users;
use util::session::auth;

let mut path = app.push("/api");

path.route("/users", users::collection(auth))
    .route("/:user-id", users::member(auth));
```

## Permutations

```rust
// Generate `collection` and `member` scopes.
via::resource!(app = Unicorn);

// Only generate the `collection` scope.
via::resource!(app = Unicorn, only = collection);

// Only generate the `member` scope.
via::resource!(app = Unicorn, only = member);

// Generate the `collection` scope with a single action: `create`.
via::resource!(app = Unicorn, only = create);

// Omit the `create` action from the generated scopes.
via::resource!(app = Unicorn, only = [index, member]);

// Both scopes take a `predicate` factory function as an argument.
via::resource!(app = Unicorn, guard);

// Only the `collection` scope takes a `predicate` argument.
via::resource!(app = Unicorn, guard = collection);

// Both the `collection` and `member` scope take a `predicate` argument
// but it doesn't apply to the `create` action.
via::resource!(app = Unicorn, guard = [index, member]);

// Any request to a generated scope with unsupported method will `405`.
via::resource!(app = Unicorn, exhaustive);

// Request to the `collection` scope with unsupported method will `405`.
via::resource!(app = Unicorn, exhaustive = collection);

// Request to the `member` scope with unsupported method will `405`.
via::resource!(app = Unicorn, exhaustive = member);

// Generate the `collection` and `member` scope. Exclude `create` from the
// `collection` scope and only apply the guard predicate factory to the
// `index` and `destroy` actions. Requests to either scope with an
// unsupported method will `405`.
via::resource!(
    app = Unicorn,
    only = [index, member],
    guard = [index, destroy],
    exhaustive,
);
```