### PR TITLE
feat(via): capability-bounded rescue policies

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -38,11 +38,7 @@ async fn main() -> via::Result<ExitCode> {
     let mut app = via::app(());
 
     // Errors that occur further down the stack generate a JSON response.
-    app.middleware(
-        rescue::canonical_reason_phrase()
-            .and(rescue::json())
-            .build(),
-    );
+    app.middleware(rescue::json().build());
 
     // If the client does not speak JSON, deny the request.
     app.middleware(guard::barrier(guard::content!(media::json())));

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -38,7 +38,11 @@ async fn main() -> via::Result<ExitCode> {
     let mut app = via::app(());
 
     // Errors that occur further down the stack generate a JSON response.
-    app.middleware(rescue(|error| error.use_json()));
+    app.middleware(
+        rescue::canonical_reason_phrase()
+            .and(rescue::json())
+            .build(),
+    );
 
     // If the client does not speak JSON, deny the request.
     app.middleware(guard::barrier(guard::content!(media::json())));

--- a/via/src/before.rs
+++ b/via/src/before.rs
@@ -83,7 +83,7 @@ pub struct Before<T, U> {
 ///     let mut api = app.push("api");
 ///
 ///     // If an error occurs, respond with JSON.
-///     api.middleware(rescue(|sanitizer| sanitizer.use_json()));
+///     api.middleware(rescue::json().build());
 ///
 ///     // Parse and track changes that are made to the session cookie.
 ///     api.middleware(cookies([session::COOKIE]));

--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -3,9 +3,10 @@
 
 mod catch;
 mod macros;
-mod rescue;
 mod result;
 mod server;
+
+pub mod rescue;
 
 use http::{StatusCode, header};
 use serde::ser::SerializeSeq;
@@ -16,7 +17,6 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::io::{self, Error as IoError};
 
 pub use catch::{Catch, Propagate};
-pub use rescue::{Rescue, Sanitizer, rescue};
 pub use result::ResultExt;
 pub(crate) use server::ServerError;
 

--- a/via/src/error/rescue.rs
+++ b/via/src/error/rescue.rs
@@ -1,156 +1,294 @@
+//! Recover from service errors with capability-bounded policies.
+//!
+//! Unlike traditional exception handlers or recovery callbacks, rescue
+//! policies cannot arbitrarily construct responses. Instead, they observe a
+//! recovered [`Error`] and request predefined rendering behavior such as JSON
+//! output, canonical reason phrases, or connection termination.
+//!
+//! This separation of concerns keeps response construction within Via while
+//! still allowing applications to customize how errors are presented and
+//! reported. Policies may also perform side effects such as logging or
+//! telemetry without influencing the rendered response.
+//!
+//! Policies compose declaratively:
+//!
+//! ```no_run
+//! use via::error::rescue;
+//!
+//! let policy = rescue::canonical_reason_phrase()
+//!     .and(rescue::connection_close())
+//!     .and(rescue::json())
+//!     .build();
+//! ```
+//!
+//! The resulting middleware may be applied to any portion of the middleware
+//! stack, allowing different trust boundaries to expose different recovery
+//! policies.
+
+use bitflags::bitflags;
 use http::StatusCode;
 use http::header::{ALLOW, CONNECTION};
 use std::borrow::Cow;
-use std::fmt::{self, Display, Formatter};
+use std::fmt::Display;
 use std::sync::Arc;
 
 use super::{Error, ErrorSourceRef, Errors};
 use crate::middleware::{BoxFuture, Middleware};
 use crate::response::{Finalize, Response, ResponseBuilder};
+use crate::util::sealed;
 use crate::{Next, Request};
 
-/// Recover from errors that occur in downstream middleware.
+/// A bounded error recovery policy.
 ///
-pub struct Rescue<F> {
-    recover: Arc<F>,
+/// A `Policy` determines how a recovered [`Error`] should be rendered without
+/// granting authority to construct arbitrary responses.
+///
+/// Policies receive the recovered error together with the accumulated
+/// [`PolicyFlags`], and return the updated flags. Multiple policies may be
+/// composed with [`PolicyBuilder::and`].
+///
+/// This trait is sealed and cannot be implemented outside of Via.
+pub trait Policy: sealed::Sealed {
+    fn apply(&self, error: &Error, flags: PolicyFlags) -> PolicyFlags;
 }
 
-/// Customize how an [`Error`] is converted to a response.
+/// Compose two recovery policies.
 ///
-pub struct Sanitizer<'a> {
-    json: bool,
-    keep_alive: bool,
-    error: &'a mut Error,
-    message: Option<Cow<'a, str>>,
+/// Policies are applied from left to right.
+pub struct And<T, U>(T, U);
+
+/// Use the HTTP status reason phrase as the error message.
+///
+/// When enabled, the rendered response body contains the canonical reason
+/// phrase associated with the response status code instead of the original
+/// error message.
+pub struct CanonicalReasonPhrase;
+
+/// Instruct the client to close the connection.
+///
+/// When enabled, the rendered response includes a `Connection: close` header.
+pub struct ConnectionClose;
+
+/// Render recovered errors as JSON.
+///
+/// When enabled, the error is serialized to JSON that is compatible with both
+/// GraphQL and JSON::API.
+pub struct Json;
+
+/// Incrementally construct a recovery policy.
+///
+/// Builders may be combined with [`PolicyBuilder::and`] before being converted
+/// into a [`Rescue`] middleware with [`PolicyBuilder::build`].
+pub struct PolicyBuilder<T> {
+    policy: T,
 }
 
-/// Sanitize errors that occur in downstream middleware.
+/// The accumulated state of a recovery policy.
 ///
-pub fn rescue<F>(recover: F) -> Rescue<F>
-where
-    F: Fn(&mut Sanitizer) + Copy + Send + Sync,
-{
-    Rescue {
-        recover: Arc::new(recover),
+/// `PolicyFlags` records which rendering behaviors have been requested by the
+/// composed recovery policy.
+pub struct PolicyFlags {
+    mask: PolicyMask,
+}
+
+/// Inspect the recovered error before a response is generated from it.
+///
+/// The callback receives an opaque display view of the recovered error.
+///
+/// This allows diagnostics such as logging or telemetry without exposing the
+/// structured error metadata used by Via to render the response.
+pub struct Inspect<F> {
+    op: F,
+}
+
+/// Recover from errors that occur in subsequent middleware.
+pub struct Rescue<T> {
+    policy: Arc<T>,
+}
+
+struct Render<'a> {
+    flags: &'a PolicyMask,
+    error: &'a Error,
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    struct PolicyMask: u8 {
+        const CANONICAL_REASON_PHRASE = 1 << 3;
+        const CONNECTION_CLOSE = 1 << 4;
+        const JSON_RESPONSE = 1 << 5;
     }
 }
 
-impl<App, F> Middleware<App> for Rescue<F>
+sealed!(
+    And<T, U>,
+    CanonicalReasonPhrase,
+    ConnectionClose,
+    Inspect<F>,
+    Json
+);
+
+/// Render the canonical HTTP reason phrase instead of the original error.
+pub fn canonical_reason_phrase() -> PolicyBuilder<CanonicalReasonPhrase> {
+    PolicyBuilder {
+        policy: CanonicalReasonPhrase,
+    }
+}
+
+/// Add a `Connection: close` header to generated responses.
+pub fn connection_close() -> PolicyBuilder<ConnectionClose> {
+    PolicyBuilder {
+        policy: ConnectionClose,
+    }
+}
+
+/// Inspect the recovered error before a response is generated from it.
+///
+/// The callback receives an opaque display view of the recovered error.
+///
+/// This allows diagnostics such as logging or telemetry without exposing the
+/// structured error metadata used by Via to render the response.
+pub fn inspect<F>(op: F) -> PolicyBuilder<Inspect<F>>
 where
-    F: Fn(&mut Sanitizer) + Copy + Send + Sync + Sized + 'static,
+    F: Fn(&dyn Display) + Copy + Send + Sync + 'static,
+{
+    PolicyBuilder {
+        policy: Inspect { op },
+    }
+}
+
+/// Render recovered errors as JSON.
+pub fn json() -> PolicyBuilder<Json> {
+    PolicyBuilder { policy: Json }
+}
+
+impl<T> PolicyBuilder<T> {
+    /// Combine two recovery policies.
+    ///
+    /// Policies are applied in the order they are combined.
+    pub fn and<U>(self, other: PolicyBuilder<U>) -> PolicyBuilder<And<T, U>> {
+        PolicyBuilder {
+            policy: And(self.policy, other.policy),
+        }
+    }
+
+    /// Build a [`Rescue`] middleware from this policy.
+    pub fn build(self) -> Rescue<T> {
+        Rescue {
+            policy: Arc::new(self.policy),
+        }
+    }
+}
+
+impl<T: Policy, U: Policy> Policy for And<T, U> {
+    fn apply(&self, error: &Error, flags: PolicyFlags) -> PolicyFlags {
+        let flags = self.0.apply(error, flags);
+        self.1.apply(error, flags)
+    }
+}
+
+impl Policy for CanonicalReasonPhrase {
+    fn apply(&self, _: &Error, flags: PolicyFlags) -> PolicyFlags {
+        flags.set(PolicyMask::CANONICAL_REASON_PHRASE)
+    }
+}
+
+impl Policy for ConnectionClose {
+    fn apply(&self, _: &Error, flags: PolicyFlags) -> PolicyFlags {
+        flags.set(PolicyMask::CONNECTION_CLOSE)
+    }
+}
+
+impl<F> Policy for Inspect<F>
+where
+    F: Fn(&dyn Display) + Send + Sync + 'static,
+{
+    fn apply(&self, error: &Error, flags: PolicyFlags) -> PolicyFlags {
+        (self.op)(error);
+        flags
+    }
+}
+
+impl Policy for Json {
+    fn apply(&self, _: &Error, flags: PolicyFlags) -> PolicyFlags {
+        flags.set(PolicyMask::JSON_RESPONSE)
+    }
+}
+
+impl PolicyFlags {
+    fn new() -> Self {
+        Self {
+            mask: PolicyMask::empty(),
+        }
+    }
+
+    fn set(self, flag: PolicyMask) -> Self {
+        Self {
+            mask: self.mask | flag,
+        }
+    }
+}
+
+impl<T, App> Middleware<App> for Rescue<T>
+where
+    T: Policy + Send + Sync + 'static,
 {
     fn call(&self, request: Request<App>, next: Next<App>) -> BoxFuture {
-        let recover = Arc::clone(&self.recover);
+        let policy = Arc::clone(&self.policy);
         let future = next.call(request);
 
         Box::pin(async move {
-            future.await.or_else(|mut error| {
-                let mut sanitizer = Sanitizer::new(&mut error);
-                (recover)(&mut sanitizer);
+            future.await.or_else(|error| {
+                let flags = policy.apply(&error, PolicyFlags::new());
 
-                let response = Response::build();
-                sanitizer.finalize(response).or_else(|residual| {
-                    if cfg!(debug_assertions) {
-                        eprintln!("warn: a residual error occurred in rescue");
-                        eprintln!("{}", residual);
-                    }
-
-                    Ok(error.into())
-                })
+                Render::new(&flags.mask, &error)
+                    .finalize(Response::build())
+                    .or_else(|residual| {
+                        log!(warn(rescue = 0), "a residual error occurred in rescue");
+                        log!(warn(rescue = 1), "{}", &residual);
+                        Ok(error.into())
+                    })
             })
         })
     }
 }
 
-impl<'a> Sanitizer<'a> {
-    /// Returns a reference to the error source.
-    ///
-    pub fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.error.source()
-    }
-
-    /// If `false` a connection `close` header will be added to the response.
-    pub fn keep_alive(&mut self, keep_alive: bool) {
-        self.keep_alive = keep_alive;
-    }
-
-    /// Provide a custom message to use for the response generated from this
-    /// error.
-    ///
-    pub fn set_message<T>(&mut self, message: T)
-    where
-        Cow<'a, str>: From<T>,
-    {
-        self.message = Some(message.into());
-    }
-
-    /// Overrides the HTTP status code of the error.
-    ///
-    pub fn set_status(&mut self, status: StatusCode) {
-        self.error.status = status;
-    }
-
-    /// Use the canonical reason of the status code as the error message.
-    ///
-    pub fn use_canonical_reason(&mut self) {
-        self.message = self.status().canonical_reason().map(Cow::Borrowed);
-    }
-
-    /// Generate a json response for the error.
-    ///
-    pub fn use_json(&mut self) {
-        self.json = true;
-    }
-
-    fn status(&self) -> StatusCode {
-        self.error.status
+impl<'a> Render<'a> {
+    fn new(flags: &'a PolicyMask, error: &'a Error) -> Self {
+        Self { flags, error }
     }
 }
 
-impl<'a> Sanitizer<'a> {
-    fn new(error: &'a mut Error) -> Self {
-        Self {
-            json: false,
-            keep_alive: true,
-            error,
-            message: None,
-        }
-    }
-}
-
-impl Display for Sanitizer<'_> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Display::fmt(self.error, f)
-    }
-}
-
-impl Finalize for Sanitizer<'_> {
-    fn finalize(mut self, builder: ResponseBuilder) -> Result<Response, Error> {
-        let mut builder = builder.status(self.status());
+impl Finalize for Render<'_> {
+    fn finalize(self, mut builder: ResponseBuilder) -> Result<Response, Error> {
+        builder = builder.status(self.error.status);
 
         if let ErrorSourceRef::AllowMethod(error) = self.error.as_source()
+            && self.error.status == StatusCode::METHOD_NOT_ALLOWED
             && let Some(allow) = error.allows()
         {
             builder = builder.header(ALLOW, allow);
         }
 
-        if !self.keep_alive {
+        if self.flags.contains(PolicyMask::CONNECTION_CLOSE) {
             builder = builder.header(CONNECTION, "close");
         }
 
-        if self.json {
-            let json = self.message.take().map_or_else(
-                || self.error.repr_json(),
-                |message| {
-                    let mut errors = Errors::new(self.status());
-                    errors.push(message);
-                    errors
-                },
-            );
-
-            builder.json(&json)
-        } else if let Some(message) = self.message {
-            builder.text(message)
+        if self.flags.contains(PolicyMask::JSON_RESPONSE) {
+            if self.flags.contains(PolicyMask::CANONICAL_REASON_PHRASE)
+                && let Some(reason_phrase) = self.error.status.canonical_reason()
+            {
+                let mut errors = Errors::new(self.error.status);
+                errors.push(Cow::Borrowed(reason_phrase));
+                builder.json(&errors)
+            } else {
+                let errors = self.error.repr_json();
+                builder.json(&errors)
+            }
+        } else if self.flags.contains(PolicyMask::CANONICAL_REASON_PHRASE)
+            && let Some(reason_phrase) = self.error.status.canonical_reason()
+        {
+            builder.text(reason_phrase)
         } else {
             builder.text(self.error.to_string())
         }

--- a/via/src/middleware.rs
+++ b/via/src/middleware.rs
@@ -222,7 +222,7 @@ pub type Result<T = Response> = std::result::Result<T, Error>;
 ///
 ///     // Errors originating from the /api namespace generate a
 ///     // JSON response.
-///     api.middleware(rescue(|error| error.use_json()));
+///     api.middleware(rescue::json().build());
 ///
 ///     // Confirm the client speaks JSON. Then, restore their
 ///     // session.

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -11,23 +11,14 @@ use std::task::{Context, Poll, ready};
 use std::time::Duration;
 use zeroize::Zeroize;
 
+#[cfg(feature = "tokio-tungstenite")]
+use tungstenite::protocol::Message;
+
+#[cfg(feature = "tokio-websockets")]
+use tokio_websockets::Message;
+
+use crate::util::sealed;
 use crate::{Error, err};
-
-mod sealed {
-    /// Prevents external implementations of Payload. Allowing us to make
-    /// assumptions about the data contained by implementations of Payload.
-    pub trait Sealed {}
-
-    impl Sealed for super::Aggregate {}
-
-    impl Sealed for bytes::Bytes {}
-
-    #[cfg(feature = "tokio-tungstenite")]
-    impl Sealed for tungstenite::protocol::Message {}
-
-    #[cfg(feature = "tokio-websockets")]
-    impl Sealed for tokio_websockets::Message {}
-}
 
 /// Represents an optionally contiguous source of data received from a client.
 ///
@@ -193,6 +184,12 @@ struct RequestPayload {
     frames: Vec<Bytes>,
     trailers: Option<HeaderMap>,
 }
+
+#[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
+sealed!(Aggregate, Bytes, Message);
+
+#[cfg(not(any(feature = "tokio-tungstenite", feature = "tokio-websockets")))]
+sealed!(Aggregate, Bytes);
 
 #[inline]
 fn deserialize_json<T>(buf: &[u8]) -> Result<T, Error>
@@ -376,14 +373,10 @@ impl Payloadz for Aggregate {
 }
 
 #[cfg(feature = "tokio-tungstenite")]
-impl_payload_for_bytes_like!(tungstenite::protocol::Message);
+impl_payload_for_bytes_like!(Message);
 
 #[cfg(feature = "tokio-websockets")]
-impl_payload_for_bytes_like!(
-    tokio_websockets::Message,
-    tokio_websockets::Message::into_payload,
-    tokio_websockets::Message::binary
-);
+impl_payload_for_bytes_like!(Message, Message::into_payload, Message::binary);
 
 impl Payload for Bytes {
     fn coalesce(mut self) -> Vec<u8> {

--- a/via/src/router/route.rs
+++ b/via/src/router/route.rs
@@ -27,7 +27,7 @@ use crate::middleware::Middleware;
 ///
 ///     // If an error occurs on a descendant of /api, respond with json.
 ///     // Siblings of /api must define their own error handling logic.
-///     path.middleware(rescue(|sanitizer| sanitizer.use_json()));
+///     path.middleware(rescue::json().build());
 ///
 ///     // Define a /users resource as a child of /api so the rescue and timeout
 ///     // middleware run before any of the middleware or responders defined in

--- a/via/src/util/mod.rs
+++ b/via/src/util/mod.rs
@@ -1,8 +1,11 @@
 #[cfg(debug_assertions)]
 mod once;
+#[macro_use]
+mod sealed;
 mod uri_encoding;
 
 #[cfg(debug_assertions)]
 pub(crate) use once::once;
+pub(crate) use sealed::sealed;
 
 pub use uri_encoding::UriEncoding;

--- a/via/src/util/sealed.rs
+++ b/via/src/util/sealed.rs
@@ -1,0 +1,13 @@
+macro_rules! sealed {
+    ($($impl:ident $(<$($args:ident),*>)?),+) => {
+        mod sealed {
+            /// A marker trait used to prevent external implementations.
+            #[allow(dead_code)]
+            pub trait Sealed {}
+        }
+
+        $(impl$(<$($args),*>)? sealed::Sealed for $impl $(<$($args),*>)? {})+
+    };
+}
+
+pub(crate) use sealed;


### PR DESCRIPTION
Refactors the error rescue middleware to use capability-bounded recovery policies implemented with a sealed trait. The rescue middleware is often times the first line of defence against adversarial connections. This refactor turns what could otherwise be a high value exploit into noisy framework code.