### PR TITLE
docs(via): improved top-level module doc preview

### DIFF
--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -1,4 +1,4 @@
-//! Error handling.
+//! Raise and recover from service errors with a capability-bounded policy.
 //!
 
 mod catch;

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -1,4 +1,4 @@
-//! Synchronous predicates that shape middleware execution.
+//! Predicate-based request filters that define the middleware stack shape.
 //!
 //! Guards are stateless higher-order middleware. They classify a request before
 //! asynchronous work begins and decide whether middleware should be entered or

--- a/via/src/request/mod.rs
+++ b/via/src/request/mod.rs
@@ -1,3 +1,5 @@
+//! Interact with incoming requests to your service.
+
 pub mod params;
 
 mod payload;

--- a/via/src/response/mod.rs
+++ b/via/src/response/mod.rs
@@ -1,3 +1,5 @@
+//! Build, finalize, and decorate responses from middleware.
+
 mod body;
 mod builder;
 mod redirect;

--- a/via/src/router/mod.rs
+++ b/via/src/router/mod.rs
@@ -1,3 +1,5 @@
+//! A declarative routing DSL that makes trust boundaries obvious.
+
 mod route;
 mod switch;
 

--- a/via/src/ws/mod.rs
+++ b/via/src/ws/mod.rs
@@ -1,3 +1,5 @@
+//! Support bidirectional communication over HTTP with WebSockets.
+
 #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
 compile_error!("features \"aws-lc-rs\" and \"ring\" are mutually exclusive.");
 


### PR DESCRIPTION
Uses the top-level module doc previews from #606.

<img width="1783" height="377" alt="Schermata_20260706_100630" src="https://github.com/user-attachments/assets/eb01eb48-3c13-4269-a0dd-6d2477cceb82" />
