### PR TITLE
feat(via): via::before is #[inline(always)]

### DIFF
--- a/via/src/before.rs
+++ b/via/src/before.rs
@@ -182,6 +182,7 @@ pub struct Before<T, U> {
 /// }
 /// ```
 /// </details>
+#[inline(always)]
 pub fn before<T, U>(decorator: T, middleware: U) -> Before<T, U> {
     Before {
         decorator,


### PR DESCRIPTION
Unconditionally inlines the constructor of  `via::Before` . We don't want to do binary patchers any favors.