### PR TITLE
feat(via): router scope ensures dsl correctness

### DIFF
--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,13 +1,13 @@
 use cookie::{Cookie, Key, SameSite};
 use std::process::ExitCode;
 use std::time::Duration;
-use via::{Error, Next, Request, Response, ResultExt, Server};
+use via::{Error, Next, Request, Response, ResultExt, Router, Server, cookies};
 
-struct Unicorn {
+struct Buttercup {
     secret: Key,
 }
 
-async fn hello(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
+async fn hello(request: Request<Buttercup>, _: Next<Buttercup>) -> via::Result {
     let app = request.app_owned();
 
     // Get the value of the "counter" cookie from the request before passing
@@ -45,22 +45,34 @@ async fn hello(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    // Create a new application.
-    let mut app = via::app(Unicorn {
+    // Define the routes of our application, "Buttercup".
+    let router = Router::new(|mut home| {
+        // The cookies middleware can be added at any depth of the route tree.
+        //
+        // In this example, we add it at the root path of our application.
+        //
+        // This enables managed cookies for all of the subsequently defined
+        // routes.
+        home.middleware(cookies(["counter"]));
+
+        // Start defining descendants of "/".
+        let mut path = home.prefix();
+
+        // Add a route that responds with a greeting message.
+        path.route("/hello/:name", via::get(hello));
+    });
+
+    // Create our application.
+    let buttercup = Buttercup {
+        secret: Key::generate(),
         // secret: std::env::var("VIA_SECRET_KEY")
         //     .map(|secret| secret.as_bytes().try_into())
         //     .expect("missing required env var: VIA_SECRET_KEY")
         //     .expect("unexpected end of input while parsing VIA_SECRET_KEY"),
-        secret: Key::generate(),
-    });
+    };
 
-    // The Cookies middleware can be added at any depth of the route tree.
-    // In this example, we add it at the root path of our application. This
-    // enables cookie support for all of the subsequently defined middlewares.
-    app.middleware(via::cookies(["counter"]));
-
-    // Add a route that responds with a greeting message.
-    app.route("/hello/:name", via::get(hello));
-
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    // Start listening at http://localhost:8080/ for incoming requests.
+    Server::new(router, buttercup)
+        .listen(("127.0.0.1", 8080))
+        .await
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,5 +1,5 @@
 use std::process::ExitCode;
-use via::{Error, Finalize, Next, Request, Response, Server};
+use via::{Error, Finalize, Next, Request, Response, Router, Server};
 
 async fn echo(request: Request, _: Next) -> via::Result {
     request.finalize(Response::build())
@@ -36,12 +36,18 @@ async fn relay(mut channel: via::ws::Channel, _: via::ws::Request) -> via::ws::R
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let mut app = via::app(());
+    // Define the routes that our application responds to.
+    let router = Router::new(|home| {
+        // Start defining descendants of "/".
+        let mut path = home.prefix();
 
-    #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
-    let relay = via::ws(relay);
+        // If a ws backend is enabled, GET /echo opens a ws relay.
+        #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
+        let relay = via::ws(relay);
 
-    app.route("/echo", via::post(echo).get(relay));
+        path.route("/echo", via::post(echo).get(relay));
+    });
 
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    // Start listening at http://localhost:8080/ for incoming requests.
+    Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
-use via::{Error, Next, Request, Server};
+use via::{Error, Next, Request, Router, Server};
 
 /// The maximum number of connections we are willing to accept before
 /// accounting for resources other than TCP connections.
@@ -18,7 +18,7 @@ const MAX_CONNECTIONS: usize = 1024;
 const RT_FD_REQUIREMENT: usize = 13;
 
 #[cfg_attr(not(feature = "fs"), allow(dead_code))]
-struct Unicorn {
+struct Bubblegum {
     /// The directory from which files can be served.
     public_dir: Box<Path>,
 
@@ -27,8 +27,17 @@ struct Unicorn {
     semaphore: Arc<Semaphore>,
 }
 
+impl Bubblegum {
+    fn new(max_open_files: usize) -> Self {
+        Self {
+            public_dir: resolve_public_dir().into_boxed_path(),
+            semaphore: Arc::new(Semaphore::new(max_open_files)),
+        }
+    }
+}
+
 #[cfg_attr(not(feature = "fs"), allow(dead_code))]
-impl Unicorn {
+impl Bubblegum {
     fn public_dir(&self) -> &Path {
         &self.public_dir
     }
@@ -61,7 +70,7 @@ fn determine_resource_usage() -> via::Result<(usize, usize)> {
 
 /// Extracts the relative path to the requested file from the request.
 #[cfg(feature = "fs")]
-fn extract_file_path(request: &Request<Unicorn>) -> via::Result<PathBuf> {
+fn extract_file_path(request: &Request<Bubblegum>) -> via::Result<PathBuf> {
     let public_dir = request.app().public_dir();
 
     if let Some(path_param) = request.param("path").ok()?.as_deref() {
@@ -83,7 +92,7 @@ fn resolve_public_dir() -> PathBuf {
 }
 
 #[cfg(feature = "fs")]
-async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
+async fn serve_dir(request: Request<Bubblegum>, _: Next<Bubblegum>) -> via::Result {
     use std::ffi::OsStr;
     use via::response::File;
 
@@ -105,27 +114,28 @@ async fn serve_dir(request: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
 }
 
 #[cfg(not(feature = "fs"))]
-async fn serve_dir(_: Request<Unicorn>, _: Next<Unicorn>) -> via::Result {
+async fn serve_dir(_: Request<Bubblegum>, _: Next<Bubblegum>) -> via::Result {
     panic!("the \"fs\" feature flag is required in order to run the files example.");
 }
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let (max_open_files, max_connections) = determine_resource_usage()?;
-    let mut app = via::app(Unicorn {
-        public_dir: resolve_public_dir().into_boxed_path(),
-        semaphore: Arc::new(Semaphore::new(max_open_files)),
-    });
-
-    app.route("/*path", via::get(serve_dir));
-
     if cfg!(not(feature = "fs")) {
         eprintln!("    the \"fs\" feature flag is required in order to run the files example.");
         eprintln!("    re-run this example with cargo run --example files --feature=\"fs\"");
         return Ok(ExitCode::FAILURE);
     }
 
-    Server::new(app)
+    // Define the routes of our file serving application, "Bubblegum".
+    let router = Router::new(|home| {
+        home.prefix().route("/*path", via::get(serve_dir));
+    });
+
+    // Setup our file serving application.
+    let (max_open_files, max_connections) = determine_resource_usage()?;
+    let bubblegum = Bubblegum::new(max_open_files);
+
+    Server::new(router, bubblegum)
         .max_connections(max_connections)
         .listen(("127.0.0.1", 8080))
         .await

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,5 +1,5 @@
 use std::process::ExitCode;
-use via::{Error, Next, Request, Response, ResultExt, Server};
+use via::{Next, Request, Response, ResultExt, Router, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result {
     // Get a reference to `name` from the request uri path.
@@ -10,11 +10,16 @@ async fn hello(request: Request, _: Next) -> via::Result {
 }
 
 #[tokio::main]
-async fn main() -> Result<ExitCode, Error> {
-    let mut app = via::app(());
+async fn main() -> via::Result<ExitCode> {
+    // Define the routes that our application responds to.
+    let router = Router::new(|home| {
+        // Start defining descendants of "/".
+        let mut path = home.prefix();
 
-    // Define a route that listens on /hello/:name.
-    app.route("/hello/:name", via::get(hello));
+        // Define a route that listens on /hello/:name.
+        path.route("/hello/:name", via::get(hello));
+    });
 
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    // Start listening at http://localhost:8080/ for incoming requests.
+    Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::process::ExitCode;
 use via::guard::{self, media};
-use via::{Next, Payload, Request, Response, Server, rescue};
+use via::{Next, Request, Response, Router, Server, rescue};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Document<T> {
@@ -19,6 +19,8 @@ struct Hello {
 }
 
 async fn hello(request: Request, _: Next) -> via::Result {
+    use via::request::Payload;
+
     // A future that resolves with the frames that compose the request body.
     let (body, _app) = request.into_future();
 
@@ -35,16 +37,21 @@ async fn hello(request: Request, _: Next) -> via::Result {
 
 #[tokio::main]
 async fn main() -> via::Result<ExitCode> {
-    let mut app = via::app(());
+    // Define the routes that our application responds to.
+    let router = Router::new(|mut home| {
+        // Errors that occur further down the stack generate a JSON response.
+        home.middleware(rescue::json().build());
 
-    // Errors that occur further down the stack generate a JSON response.
-    app.middleware(rescue::json().build());
+        // If the client does not speak JSON, deny the request.
+        home.middleware(guard::barrier(guard::content!(media::json())));
 
-    // If the client does not speak JSON, deny the request.
-    app.middleware(guard::barrier(guard::content!(media::json())));
+        // Start defining descendants of "/".
+        let mut path = home.prefix();
 
-    // Define a route that responds to POST /hello.
-    app.route("/hello", via::post(hello).or_deny());
+        // Define a route that listens on /hello/:name.
+        path.route("/hello", via::post(hello).or_deny());
+    });
 
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    // Start listening at http://localhost:8080/ for incoming requests.
+    Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -30,7 +30,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
     // Send a JSON response with our greeting message.
     Response::build().json(&Document {
         data: Greeting {
-            message: format!("Hello, {}!", &hello.data.name),
+            message: format!("Hello, {}!", hello.data.name),
         },
     })
 }

--- a/examples/native-tls/main.rs
+++ b/examples/native-tls/main.rs
@@ -60,23 +60,25 @@ fn resolve_example_dir() -> PathBuf {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let example_dir = resolve_example_dir();
+    // Define the routes of our application.
+    let router = Router::new(|home| {
+        let mut path = home.prefix();
+
+        // Add our hello responder to the endpoint /hello/:name.
+        path.route("/hello/:name", via::get(hello));
+
+        #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
+        path.route("/echo", via::get(via::ws(echo)));
+    });
 
     // Load our .env file containing TLS_PKCS_PASSWORD.
     dotenvy::from_filename(example_dir.join(".env"))?;
 
     // Make sure that our TLS config is present and valid before we proceed.
+    let example_dir = resolve_example_dir();
     let tls_config = load_pkcs12(&example_dir)?;
 
-    let mut app = via::app(());
-
-    // Add our hello responder to the endpoint /hello/:name.
-    app.route("/hello/:name", via::get(hello));
-
-    #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
-    app.route("/echo", via::get(via::ws(echo)));
-
-    Server::new(app)
+    Server::new(router, ())
         .listen_native_tls(("127.0.0.1", 8080), tls_config)
         .await
 }

--- a/examples/rustls/main.rs
+++ b/examples/rustls/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use via::{Error, Next, Request, Response, ResultExt, Server};
+use via::{Error, Next, Request, Response, ResultExt, Router, Server};
 
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -45,20 +45,22 @@ fn resolve_example_dir() -> PathBuf {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let example_dir = resolve_example_dir();
+    // Define the routes of our application.
+    let router = Router::new(|home| {
+        let mut path = home.prefix();
+
+        // Add our hello responder to the endpoint /hello/:name.
+        path.route("/hello/:name", via::get(hello));
+
+        #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
+        path.route("/echo", via::get(via::ws(echo)));
+    });
 
     // Make sure that our TLS config is present and valid before we proceed.
+    let example_dir = resolve_example_dir();
     let tls_config = tls::server_config(&example_dir)?;
 
-    let mut app = via::app(());
-
-    // Add our hello responder to the endpoint /hello/:name.
-    app.route("/hello/:name", via::get(hello));
-
-    #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
-    app.route("/echo", via::get(via::ws(echo)));
-
-    Server::new(app)
+    Server::new(router, ())
         .listen_rustls_23(("127.0.0.1", 8080), tls_config)
         .await
 }

--- a/via/src/app/mod.rs
+++ b/via/src/app/mod.rs
@@ -4,110 +4,18 @@ mod shared;
 pub(crate) use service::ServiceAdapter;
 pub use shared::Shared;
 
-use delegate::delegate;
+use crate::router::Router;
 
-use crate::middleware::Middleware;
-use crate::router::{Route, Router};
-
-/// Configure routes and define shared global state.
-///
-/// # Example
-///
-/// ```no_run
-/// use std::process::ExitCode;
-/// use via::{Error, Next, Request, Server, Shared};
-///
-/// /// A mock database pool.
-/// #[derive(Debug)]
-/// struct DatabasePool {
-///     url: String,
-/// }
-///
-/// /// Shared global state. Named after our application.
-/// struct Unicorn {
-///     pool: DatabasePool,
-/// }
-///
-/// impl Unicorn {
-///     fn pool(&self) -> &DatabasePool {
-///         &self.pool
-///     }
-/// }
-///
-/// #[tokio::main]
-/// async fn main() -> Result<ExitCode, Error> {
-///     // Pass our shared state struct containing a database pool to the App
-///     // constructor so it can be used to serve each request.
-///     let mut app = via::app(Unicorn {
-///         pool: DatabasePool {
-///             url: std::env::var("DATABASE_URL")?,
-///         },
-///     });
-///
-///     // We can access our database in middleware with `request.app()`.
-///     app.middleware(async |request: Request<Unicorn>, next: Next<Unicorn>| {
-///         // Print the debug output of our mock database pool to stdout.
-///         println!("{:?}", request.app().pool());
-///
-///         // Delegate to the next middleware to get a response.
-///         next.call(request).await
-///     });
-///
-///     // Start serving our application from http://localhost:8080/.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
-/// }
-/// ```
-///
-pub struct Via<App> {
-    app: Shared<App>,
+pub(crate) struct Via<App> {
     router: Router<App>,
-}
-
-/// Create a new app with the provided state argument.
-///
-/// # Example
-///
-/// ```
-/// # struct DatabasePool { url: String }
-/// # struct Unicorn { pool: DatabasePool }
-/// #
-/// let mut app = via::app(Unicorn {
-///     pool: DatabasePool {
-///         url: "postgres://unicorn@localhost/unicorn".to_owned(),
-///     },
-/// });
-/// ```
-///
-pub fn app<App>(app: App) -> Via<App> {
-    Via {
-        app: Shared::new(app),
-        router: Router::new(),
-    }
+    app: Shared<App>,
 }
 
 impl<App> Via<App> {
-    delegate! {
-        to self.router {
-            /// Append the provided middleware to applications call stack.
-            ///
-            /// Middleware attached with this method runs for every request.
-            ///
-            /// See also the usage example in [`Route::middleware`].
-            pub fn middleware<T>(&mut self, middleware: T)
-            where
-                T: Middleware<App> + 'static;
-
-            /// Returns a new route as a child of the root path `/`.
-            ///
-            /// See also the usage example in [`Route::route`].
-            pub fn push(&mut self, path: &'static str) -> Route<'_, App>;
-
-            /// Returns a new route as a child of the root path `/`.
-            ///
-            /// See also the usage example in [`Route::route`].
-            pub fn route<T>(&mut self, path: &'static str, middleware: T) -> Route<'_, App>
-            where
-                T: Middleware<App> + 'static;
+    pub(crate) fn new(router: Router<App>, app: App) -> Self {
+        Self {
+            router,
+            app: Shared::new(app),
         }
     }
 }

--- a/via/src/app/service.rs
+++ b/via/src/app/service.rs
@@ -6,10 +6,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use super::Via;
 use crate::request::{Envelope, Request, RequestBody};
 use crate::response::{Response, ResponseBody};
 use crate::server::ServerConfig;
-use crate::{BoxFuture, Next, Via, err};
+use crate::{BoxFuture, Next, err};
 
 const MAX_URI_PATH_LEN: usize = 8092; // 8 KB
 

--- a/via/src/before.rs
+++ b/via/src/before.rs
@@ -49,13 +49,13 @@ pub struct Before<T, U> {
 ///     # use via::guard::Predicate;
 ///     # use via::{Middleware, Request};
 ///     #
-///     # use super::Unicorn;
+///     # use super::Buttercup;
 ///     #
 ///     # pub const COOKIE: &str = "via-session";
 ///     #
-///     # pub fn needs_verified() -> fn(&Request<Unicorn>) -> bool { |_| true }
-///     # pub fn restore(_: &mut Request<Unicorn>) -> Result<(), Catch> { todo!() }
-///     # pub fn verify() -> impl Middleware<Unicorn> + 'static {
+///     # pub fn needs_verified() -> fn(&Request<Buttercup>) -> bool { |_| true }
+///     # pub fn restore(_: &mut Request<Buttercup>) -> Result<(), Catch> { todo!() }
+///     # pub fn verify() -> impl Middleware<Buttercup> + 'static {
 ///     #     via::middleware(|request, next| next.call(request))
 ///     # }
 /// }
@@ -63,55 +63,67 @@ pub struct Before<T, U> {
 /// use cookie::Key;
 /// use std::process::ExitCode;
 /// use via::guard::{self, media, method};
-/// use via::{Error, Server, cookies, rescue};
+/// use via::{Router, Server, cookies, rescue};
 ///
-/// struct Unicorn {
+/// struct Buttercup {
 ///     secret: Key,
 /// }
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<ExitCode, Error> {
-///     let mut app = via::app(Unicorn {
+/// async fn main() -> via::Result<ExitCode> {
+///     // Define the routes that our application responds to.
+///     let router = Router::new(|home| {
+///         // Start defining descendants of "/".
+///         let mut path = home.prefix();
+///
+///         // The /api namespace.
+///         let mut api = path.push("api");
+///
+///         // If an error occurs, respond with JSON.
+///         api.middleware(rescue::json().build());
+///
+///         // Parse and track changes that are made to the session cookie.
+///         api.middleware(cookies([session::COOKIE]));
+///
+///         // Content negotiation and authentication guards.
+///         api.middleware(guard::flat_map(
+///             // Confirm that the client speaks JSON.
+///             guard::content!(media::json()),
+///             // Then, initialize the active user session.
+///             via::before(
+///                 // Restore an identity token from the session cookie.
+///                 session::restore,
+///                 // If the request is read only or the active users account has
+///                 // been confirmed to exist in the past hour, skip verification.
+///                 //
+///                 // Such an optimization is sound so long as your app is the
+///                 // authoritative source of truth for the session and you
+///                 // properly end websocket sessions when a user deletes their
+///                 // account.
+///                 guard::filter(
+///                     guard::or((method::is_mutation(), session::needs_verified())),
+///                     session::verify(),
+///                 ),
+///             ),
+///         ));
+///
+///         // Start defining descendants of "/api".
+///         let mut path = api.prefix();
+///     });
+///
+///     // Setup our application, "Buttercup".
+///     let buttercup = Buttercup {
 ///         secret: Key::generate(),
 ///         // secret: std::env::var("VIA_SECRET_KEY")
 ///         //     .map(|secret| secret.as_bytes().try_into())
 ///         //     .expect("missing required env var: VIA_SECRET_KEY")
 ///         //     .expect("unexpected end of input while parsing VIA_SECRET_KEY"),
-///     });
+///     };
 ///
-///     // The /api namespace.
-///     let mut api = app.push("api");
-///
-///     // If an error occurs, respond with JSON.
-///     api.middleware(rescue::json().build());
-///
-///     // Parse and track changes that are made to the session cookie.
-///     api.middleware(cookies([session::COOKIE]));
-///
-///     // Content negotiation and authentication guards.
-///     api.middleware(guard::flat_map(
-///         // Confirm that the client speaks JSON.
-///         guard::content!(media::json()),
-///         // Then, initialize the active user session.
-///         via::before(
-///             // Restore an identity token from the session cookie.
-///             session::restore,
-///             // If the request is read only or the active users account has
-///             // been confirmed to exist in the past hour, skip verification.
-///             //
-///             // Such an optimization is sound so long as your app is the
-///             // authoritative source of truth for the session and you
-///             // properly end websocket sessions when a user deletes their
-///             // account.
-///             guard::filter(
-///                 guard::or((method::is_mutation(), session::needs_verified())),
-///                 session::verify(),
-///             ),
-///         ),
-///     ));
-///
-///     // Serve the application at http://localhost:8080/.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     // Start listening at http://localhost:8080 for incoming requests.
+///     Server::new(router, buttercup)
+///         .listen(("127.0.0.1", 8080))
+///         .await
 ///}
 /// ```
 ///

--- a/via/src/cookies.rs
+++ b/via/src/cookies.rs
@@ -27,7 +27,7 @@ struct SetCookieError;
 /// use cookie::{Cookie, SameSite};
 /// use std::process::ExitCode;
 /// use std::time::Duration;
-/// use via::{Error, Next, Request, Response, ResultExt, Server, cookies};
+/// use via::{Next, Request, Response, ResultExt, Router, Server, cookies};
 ///
 /// async fn greet(request: Request, _: Next) -> via::Result {
 ///     // `should_set_name` indicates whether "name" was sourced from the
@@ -60,17 +60,21 @@ struct SetCookieError;
 /// }
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<ExitCode, Error> {
-///     let mut app = via::app(());
+/// async fn main() -> via::Result<ExitCode> {
+///     // Define the routes that our application responds to.
+///     let router = Router::new(|mut home| {
+///         // Provide cookie support for downstream middleware.
+///         home.middleware(via::cookies(["name"]).decode());
 ///
-///     // Provide cookie support for downstream middleware.
-///     app.middleware(via::cookies(["name"]).decode());
+///         // Start defining descendants of "/".
+///         let mut path = home.prefix();
 ///
-///     // Respond with a greeting when a user visits /hello/:name.
-///     app.route("/hello/:name", via::get(greet));
+///         // Respond with a greeting when a user visits /hello/:name.
+///         path.route("/hello/:name", via::get(greet));
+///     });
 ///
 ///     // Start serving our application from http://localhost:8080/.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
 ///
@@ -132,7 +136,7 @@ struct SetCookieError;
 /// use serde::Deserialize;
 /// use std::process::ExitCode;
 /// use std::time::Duration;
-/// use via::{Error, Next, Payload, Request, Response, Server, cookies};
+/// use via::{Next, Payload, Request, Response, Router, Server, cookies};
 ///
 /// #[derive(Deserialize)]
 /// struct Login {
@@ -173,17 +177,21 @@ struct SetCookieError;
 /// }
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<ExitCode, Error> {
-///     let mut app = via::app(());
+/// async fn main() -> via::Result<ExitCode> {
+///     // Define the routes that our application responds to.
+///     let router = Router::new(|mut home| {
+///         // Unencoded cookie support.
+///         home.middleware(via::cookies(["session"]));
 ///
-///     // Unencoded cookie support.
-///     app.middleware(via::cookies(["session"]));
+///         // Start defining descendants of "/".
+///         let mut path = home.prefix();
 ///
-///     // Add our login route to our application.
-///     app.route("/auth/login", via::post(login));
+///         // Add our login route to our application.
+///         path.route("/auth/login", via::post(login));
+///     });
 ///
 ///     // Start serving our application from http://localhost:8080/.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
 ///
@@ -203,8 +211,9 @@ pub struct Cookies {
 /// # Example
 ///
 /// ```
-/// # let mut app = via::app(());
+/// # via::Router::new(|mut app: via::Route| {
 /// app.middleware(via::cookies(["session"]));
+/// # });
 /// ```
 ///
 pub fn cookies<I>(allow: I) -> Cookies
@@ -231,8 +240,9 @@ impl Cookies {
     /// # Example
     ///
     /// ```
-    /// # let mut app = via::app(());
+    /// # via::Router::new(|mut app: via::Route| {
     /// app.middleware(via::cookies(["session"]).decode());
+    /// # });
     /// ```
     ///
     pub fn decode(mut self) -> Self {

--- a/via/src/guard/method.rs
+++ b/via/src/guard/method.rs
@@ -28,13 +28,14 @@
 //! before a responder is reached:
 //!
 //! ```
-//! # use via::{Next, Request, guard};
+//! # use via::{Next, Request, Router, guard};
 //! # use via::guard::method;
 //! # async fn cache(request: Request, next: Next) -> via::Result {
 //! #     next.call(request).await
 //! # }
-//! # let mut app = via::app(());
-//! app.middleware(guard::filter(method::is_safe(), cache));
+//! let router = Router::new(|mut home| {
+//!     home.middleware(guard::filter(method::is_safe(), cache));
+//! });
 //! ```
 //!
 //! Prefer a router switch when different HTTP methods should be handled by
@@ -47,13 +48,18 @@
 //! #   pub async fn create(_: Request, _: Next) -> via::Result { todo!() }
 //! # }
 //! #
-//! # let mut app = via::app(());
+//! # use via::Router;
 //! #
-//! app.push("/users").assign(
-//!     via::get(users::show)
-//!         .post(users::create)
-//!         .or_deny()
-//! );
+//! let router = Router::new(|home| {
+//!     // Start defining the descendants of "/".
+//!     let mut path = home.prefix();
+//!
+//!     path.push("/users").assign(
+//!         via::get(users::show)
+//!             .post(users::create)
+//!             .or_deny()
+//!     );
+//! });
 //! ```
 //!
 //! [`Method`]: http::Method

--- a/via/src/guard/mod.rs
+++ b/via/src/guard/mod.rs
@@ -29,8 +29,8 @@ use crate::{BoxFuture, Continue, Error, Middleware, Next};
 ///
 /// ```no_run
 /// use std::process::ExitCode;
-/// use via::guard::method;
-/// use via::{Request, Next, Server, guard};
+/// use via::guard::{self, method};
+/// use via::{Next, Request, Router, Server};
 ///
 /// async fn cache(request: Request, next: Next) -> via::Result {
 ///     todo!("implement a simple response cache.");
@@ -38,12 +38,12 @@ use crate::{BoxFuture, Continue, Error, Middleware, Next};
 ///
 /// #[tokio::main]
 /// async fn main() -> via::Result<ExitCode> {
-///     let mut app = via::app(());
+///     let router = Router::new(|mut home| {
+///         // Non-idempotent requests will run the cache middleware.
+///         home.middleware(guard::filter(method::is_safe(), cache));
+///     });
 ///
-///     // Non-idempotent requests will run the cache middleware.
-///     app.middleware(guard::filter(method::is_safe(), cache));
-///
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
 pub struct Filter<T, U> {
@@ -63,7 +63,7 @@ pub struct Filter<T, U> {
 ///
 /// use std::process::ExitCode;
 /// use via::guard::{self, on};
-/// use via::{Error, Request, Server, err};
+/// use via::{Error, Request, Router, Server, err};
 ///
 /// trait Session {
 ///     fn session(&self) -> Option<&Identity>;
@@ -85,20 +85,25 @@ pub struct Filter<T, U> {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<ExitCode, Error> {
-///     let mut app = via::app(());
-///     let mut api = app.push("/api");
+///     let router = Router::new(|home| {
+///         let mut path = home.prefix();
+///         let mut api = path.push("/api");
 ///
-///     api.push("/admin/graphql").assign(guard::flat_map(
-///         guard::into_error(
-///             |request: &Request| request.is_admin(),
-///             |_| err!(403, "admin permissions are required."),
-///         ),
-///         via::post(admin::graphql)
-///             .get(admin::graphql)
-///             .or_deny(),
-///     ));
+///         // Start defining the descendants of "/api".
+///         let mut path = api.prefix();
 ///
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///         path.push("/admin/graphql").assign(guard::flat_map(
+///             guard::into_error(
+///                 |request: &Request| request.is_admin(),
+///                 |_| err!(403, "admin permissions are required."),
+///             ),
+///             via::post(admin::graphql)
+///                 .get(admin::graphql)
+///                 .or_deny(),
+///         ));
+///     });
+///
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
 pub struct FlatMap<T, U> {
@@ -115,20 +120,25 @@ pub struct FlatMap<T, U> {
 ///
 /// ```rust
 /// use via::guard::{self, media};
+/// use via::Router;
 ///
-/// let mut app = via::app(());
-/// let mut api = app.push("/api");
+/// let router = Router::new(|home: via::Route| {
+///     let mut path = home.prefix();
+///     let mut api = path.push("/api");
 ///
-/// // If the client does not speak JSON, deny the request.
-/// api.middleware(guard::barrier(guard::content!(media::json())));
+///     // If the client does not speak JSON, deny the request.
+///     api.middleware(guard::barrier(guard::content!(media::json())));
+///     // Subsequent routes defined from `api` require:
+///     //   - accept: application/json [; charset=utf-8], */*
+///     //   - content-type: application/json [; charset=utf-8]
+///     //   - content-length: ^(\d+)$ <= Server::max_request_size
 ///
-/// // Subsequent routes defined from `api` require:
-/// //   - accept: application/json [; charset=utf-8], */*
-/// //   - content-type: application/json [; charset=utf-8]
-/// //   - content-length: ^(\d+)$ <= Server::max_request_size
+///     // Start defining the descendants of "/api".
+///     let mut path = api.prefix();
 ///
-/// api.push("/users").map(|mut users| {
-///     // Define the /api/users resource.
+///     path.push("/users").map(|mut users| {
+///         // Define the /api/users resource.
+///     });
 /// });
 /// ```
 pub fn barrier<T>(predicate: T) -> FlatMap<T, Continue> {

--- a/via/src/guard/predicate.rs
+++ b/via/src/guard/predicate.rs
@@ -182,28 +182,28 @@ pub struct Any;
 /// use http::Method;
 /// use std::process::ExitCode;
 /// use via::guard::{self, method, on};
-/// use via::{Error, Request, Server};
+/// use via::{Request, Router, Server};
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<ExitCode, Error> {
-///     // Create a new application.
-///     let mut app = via::app(());
-///
-///     // If the request method is safe, cache the response.
-///     app.middleware(guard::filter(
-///         on::method(guard::or((
-///             method::get(),
-///             method::head(),
-///             method::options(),
-///             method::trace(),
-///         ))),
-///         async |request, next| {
-///             todo!("implement response caching");
-///         },
-///     ));
+/// async fn main() -> via::Result<ExitCode> {
+///     // Define the routes that our application responds to.
+///     let router = Router::new(|mut home| {
+///         // If the request method is safe, cache the response.
+///         home.middleware(guard::filter(
+///             on::method(guard::or((
+///                 method::get(),
+///                 method::head(),
+///                 method::options(),
+///                 method::trace(),
+///             ))),
+///             async |request, next| {
+///                 todo!("implement response caching");
+///             },
+///         ));
+///     });
 ///
 ///     // Serve the application at http://localhost:8080/.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
 ///
@@ -260,16 +260,16 @@ pub struct IfElse<P, T, E> {
 ///
 /// ```
 /// use http::Version;
-/// use via::{Request, guard};
+/// use via::{Request, Router, guard};
 ///
-/// // Create a new application.
-/// let mut app = via::app(());
-///
-/// // Only support request made with HTTP versions >= 1.1.
-/// app.middleware(guard::barrier(guard::into_error(
-///     |request: &Request| request.version() > Version::HTTP_10,
-///     |_| via::err!(400, "http version not supported"),
-/// )));
+/// // Define the routes that our application responds to.
+/// let router = Router::new(|mut home| {
+///     // Only support request made with HTTP versions >= 1.1.
+///     home.middleware(guard::barrier(guard::into_error(
+///         |request: &Request| request.version() > Version::HTTP_10,
+///         |_| via::err!(400, "http version not supported"),
+///     )));
+/// });
 /// ```
 pub struct IntoError<T, F> {
     predicate: T,
@@ -367,50 +367,53 @@ pub fn any() -> Any {
 /// # Example
 ///
 /// ```
-/// use via::error::Propagate;
+/// use via::error::{Error, Propagate};
 /// use via::guard::{self, Predicate, method, on};
 /// use via::ws::{self, Channel, Request};
-/// use via::{Error, err};
+/// use via::{Router, err};
 ///
 /// #[derive(Clone)]
 /// struct Session {
 ///     user_id: Option<u64>,
 /// }
 ///
-/// // Create a new application.
-/// let mut app = via::app(());
+/// // Define the routes that our application responds to.
+/// let router = Router::new(|home| {
+///     // Start defining the descendants of "/".
+///     let mut path = home.prefix();
 ///
-/// // Returns a contextual, extension-based auth predicate.
-/// let authenticate = || {
-///     guard::into_error(
-///         on::extension(|session: &Session| session.user_id.is_some()),
-///         |_| err!(401, "unauthorized.")
-///     )
-/// };
+///     // Returns a contextual, extension-based auth predicate.
+///     let authenticate = || {
+///         guard::into_error(
+///             on::extension(|session: &Session| session.user_id.is_some()),
+///             |_| err!(401, "unauthorized.")
+///         )
+///     };
 ///
-/// // Authenticated GET requests can open a web socket.
-/// app.push("/chat").assign(guard::filter(
-///     guard::or((guard::bool(method::get()), guard::bool(authenticate()))),
-///     //                                            ^^^^
-///     // The contextual predicate error is never constructed. The ErrorThunk
-///     // is dropped when the output is coerced to a boolean.
-///     //
-///     // This keeps the guard to the /chat route allocation free all while
-///     // maintaining compatibility with guards that require a contextual
-///     // predicate such as `barrier` or `flat_map`.
-///     via::ws(async |mut channel: Channel, request: Request| {
-///         while let Some(message) = channel.recv().await {
-///             if message.is_binary() || message.is_text() {
-///                 let text = message.to_text().or_continue()?;
-///                 println!("message received: {}", &text);
-///             } else if message.is_close() {
-///                 break;
+///     // Authenticated GET requests can open a web socket.
+///     path.push("/chat").assign(guard::filter(
+///         guard::or((guard::bool(method::get()), guard::bool(authenticate()))),
+///         //                                            ^^^^
+///         // The contextual predicate error is never constructed. The ErrorThunk
+///         // is dropped when the output is coerced to a boolean.
+///         //
+///         // This keeps the guard to the /chat route allocation free all while
+///         // maintaining compatibility with guards that require a contextual
+///         // predicate such as `barrier` or `flat_map`.
+///         via::ws(async |mut channel: Channel, request: Request| {
+///             while let Some(message) = channel.recv().await {
+///                 if message.is_binary() || message.is_text() {
+///                     let text = message.to_text().or_continue()?;
+///                     println!("message received: {}", &text);
+///                 } else if message.is_close() {
+///                     break;
+///                 }
 ///             }
-///         }
 ///
-///         Ok(())
-///     }),
-/// ));
+///             Ok(())
+///         }),
+///     ));
+/// });
 /// ```
 pub fn bool<T>(predicate: T) -> Bool<T> {
     Bool { predicate }
@@ -432,16 +435,16 @@ pub fn if_else<P, T, E>(predicate: P, if_true: T, or_else: E) -> IfElse<P, T, E>
 ///
 /// ```
 /// use http::Version;
-/// use via::{Request, guard};
+/// use via::{Request, Router, guard};
 ///
-/// // Create a new application.
-/// let mut app = via::app(());
-///
-/// // Only support request made with HTTP versions >= 1.1.
-/// app.middleware(guard::barrier(guard::into_error(
-///     |request: &Request| request.version() > Version::HTTP_10,
-///     |_| via::err!(400, "http version not supported"),
-/// )));
+/// // Define the routes that our application responds to.
+/// let router = Router::new(|mut home| {
+///     // Only support request made with HTTP versions >= 1.1.
+///     home.middleware(guard::barrier(guard::into_error(
+///         |request: &Request| request.version() > Version::HTTP_10,
+///         |_| via::err!(400, "http version not supported"),
+///     )));
+/// });
 /// ```
 pub fn into_error<T, F>(predicate: T, op: F) -> IntoError<T, F> {
     IntoError { predicate, op }

--- a/via/src/lib.rs
+++ b/via/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ```no_run
 //! use std::process::ExitCode;
-//! use via::{Error, Next, Request, Response, ResultExt, Server};
+//! use via::{Next, Request, Response, ResultExt, Router, Server};
 //!
 //! async fn hello(request: Request, _: Next) -> via::Result {
 //!     // Get a reference to the path parameter `name` from the request uri.
@@ -29,14 +29,18 @@
 //! }
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<ExitCode, Error> {
-//!     let mut app = via::app(());
+//! async fn main() -> via::Result<ExitCode> {
+//!     // Define the routes that our application responds to.
+//!     let router = Router::new(|home| {
+//!         // Start defining descendants of "/".
+//!         let mut path = home.prefix();
 //!
-//!     // Define a route that listens on /hello/:name.
-//!     app.route("/hello/:name", via::get(hello));
+//!         // Define a route that listens on /hello/:name.
+//!         path.route("/hello/:name", via::get(hello));
+//!     });
 //!
 //!     // Serve the application at http://localhost:8080/.
-//!     Server::new(app).listen(("127.0.0.1", 8080)).await
+//!     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 //! }
 //! ```
 //!
@@ -79,7 +83,7 @@ mod util;
 
 pub use via_macros::resource;
 
-pub use app::{Shared, Via, app};
+pub use app::Shared;
 pub use before::{Before, before};
 pub use cookies::{Cookies, cookies};
 pub use error::{Error, ResultExt, rescue};
@@ -87,7 +91,7 @@ pub use middleware::{BoxFuture, Middleware, Result, middleware};
 pub use next::{Continue, Next};
 pub use request::{Payload, Request};
 pub use response::{Finalize, Response};
-pub use router::{delete, get, head, options, patch, post, put, trace};
+pub use router::{Route, Router, delete, get, head, options, patch, post, put, trace};
 pub use server::Server;
 
 #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]

--- a/via/src/middleware.rs
+++ b/via/src/middleware.rs
@@ -37,7 +37,7 @@ pub type Result<T = Response> = std::result::Result<T, Error>;
 /// but eventually some terminal middleware will generate a response.
 ///
 /// ```
-/// use via::{Next, Request, Response, ResultExt};
+/// use via::{Next, Request, Response, ResultExt, Route};
 ///
 /// async fn hello(request: Request, _: Next) -> via::Result {
 ///     //                           ^^^^^^^
@@ -178,7 +178,7 @@ pub type Result<T = Response> = std::result::Result<T, Error>;
 /// ```no_run
 /// use std::process::ExitCode;
 /// use via::guard::{self, media, method};
-/// use via::{Error, Server, cookies, rescue};
+/// use via::{Error, Router, Server, cookies, rescue};
 ///
 /// mod session {
 ///     // Implementations elided...
@@ -209,51 +209,58 @@ pub type Result<T = Response> = std::result::Result<T, Error>;
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<ExitCode, Error> {
-///     // Create a new application.
-///     let mut app = via::app(());
+///     // Define the routes that our application responds to.
+///     let router = Router::new(|mut home| {
+///         // Cookies are parsed and managed for every request.
+///         home.middleware(cookies([session::COOKIE]));
 ///
-///     // Cookies are parsed and managed for every request.
-///     app.middleware(cookies([session::COOKIE]));
+///         // Start defining the descendants of "/".
+///         let mut path = home.prefix();
 ///
-///     // Define the /api namespace. Middleware attached to
-///     // `api` only runs for requests to a nested resource
-///     // (i.e /api/users).
-///     let mut api = app.push("/api");
+///         // The /api namespace.
+///         //
+///         // Middleware attached to `api` only runs for requests to a
+///         // resource nested in /api (i.e /api/users).
+///         let mut api = path.push("/api");
 ///
-///     // Errors originating from the /api namespace generate a
-///     // JSON response.
-///     api.middleware(rescue::json().build());
+///         // Errors originating from the /api namespace generate a
+///         // JSON response.
+///         api.middleware(rescue::json().build());
 ///
-///     // Confirm the client speaks JSON. Then, restore their
-///     // session.
-///     //
-///     // We call this pattern a "side car". A guard paired with
-///     // middleware that only executes when the guard succeeds.
-///     //
-///     // In addition to eliminating the cost of the business
-///     // logic in the subsequent middleware when the guard
-///     // fails, the framework over head of the attached
-///     // middleware is completely erased.
-///     //
-///     // It is a best practice to give a guard a side car when
-///     // it makes sense. For example, we wouldn't want to
-///     // restore a user's session to our JSON API if they cannot
-///     // send and receive JSON.
-///     api.middleware(guard::flat_map(
-///         guard::content!(media::json()),
-///         session::restore(),
-///     ));
+///         // Confirm the client speaks JSON. Then, restore their
+///         // session.
+///         //
+///         // We call this pattern a "side car". A guard paired with
+///         // middleware that only executes when the guard succeeds.
+///         //
+///         // In addition to eliminating the cost of the business
+///         // logic in the subsequent middleware when the guard
+///         // fails, the framework over head of the attached
+///         // middleware is completely erased.
+///         //
+///         // It is a best practice to give a guard a side car when
+///         // it makes sense. For example, we wouldn't want to
+///         // restore a user's session to our JSON API if they cannot
+///         // send and receive JSON.
+///         api.middleware(guard::flat_map(
+///             guard::content!(media::json()),
+///             session::restore(),
+///         ));
 ///
-///     // If the request method cannot be cached or the session
-///     // has not been verified in the past hour, confirm that
-///     // the user exists and has an active account.
-///     api.middleware(guard::filter(
-///         guard::or((method::is_mutation(), session::is_expired)),
-///         session::verify(),
-///     ));
+///         // If the request method cannot be cached or the session
+///         // has not been verified in the past hour, confirm that
+///         // the user exists and has an active account.
+///         api.middleware(guard::filter(
+///             guard::or((method::is_mutation(), session::is_expired)),
+///             session::verify(),
+///         ));
+///
+///         // Start defining the descendants of "/api".
+///         let mut path = api.prefix();
+///     });
 ///
 ///     // Serve the application at http://localhost:8080/.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
 ///

--- a/via/src/request/mod.rs
+++ b/via/src/request/mod.rs
@@ -37,7 +37,7 @@ use params::PathParam;
 /// use serde::{Deserialize, Serialize};
 /// use std::process::ExitCode;
 /// use via::request::{Envelope, Payloadz};
-/// use via::{Error, Response, ResultExt, Server};
+/// use via::{Error, Response, ResultExt, Router, Server};
 /// use zeroize::Zeroizing;
 ///
 /// type Request = via::Request<Unicorn>;
@@ -106,18 +106,25 @@ use params::PathParam;
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<ExitCode, Error> {
-///     // Define our application.
-///     let mut app = via::app(Unicorn {
-///         database: Database,
-///         telemetry: Telemetry,
+///     // Define the routes that our application responds to.
+///     let router = Router::new(|home| {
+///         // Start defining the descendants of "/".
+///         let mut path = home.prefix();
+///
+///         // Accept POST requests to /auth with the login fn.
+///         path.route("/auth", via::post(login).or_deny());
 ///     });
 ///
-///     // Accept POST requests to /auth with the login fn.
-///     app.route("/auth", via::post(login).or_deny());
+///     // Setup our application, "Unicorn".
+///     let unicorn = Unicorn {
+///         database: Database,
+///         telemetry: Telemetry,
+///     };
 ///
-///     // Listen for incoming connections at http://localhost:8080/.
-///     // We recommend enabling a TLS-backend in production.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     // Start listening at http://localhost:8080 for incoming requests.
+///     Server::new(router, unicorn)
+///         .listen(("127.0.0.1", 8080))
+///         .await
 /// }
 /// #
 /// # /// A placeholder type for your favorite database pool.
@@ -166,11 +173,13 @@ pub struct Envelope {
 ///
 /// The shared handle to your app provides a form of dependency injection,
 /// permitting per-request access to singleton resources such as a database
-/// pool. The argument passed to [`via::app`](crate::app::app) defines the
-/// resources that are made available to each request as the generic `App` type
+/// pool. The second argument passed to [`Server::new`] defines the resources
+/// that are made available to each request as the generic `App` type
 /// parameter. Connections tasks are processed asynchronously across worker
 /// threads with work-stealing scheduler. Therefore, `App` must be both
 /// [`Send`] and [`Sync`].
+///
+/// [`Server::new`]: crate::Server::new
 pub struct Request<App = ()> {
     envelope: Envelope,
     body: RequestBody,
@@ -308,14 +317,18 @@ impl<App> Request<App> {
         }
     }
 
-    /// Returns a reference to the argument passed to [`via::app`](crate::app).
+    /// Returns reference to the second argument passed to [`Server::new`].
+    ///
+    /// [`Server::new`]: crate::Server::new
     #[inline]
     pub fn app(&self) -> &App {
         &self.app
     }
 
-    /// Returns an owned, reference-counting pointer to the argument passed to
-    /// [`via::app`](crate::app).
+    /// Returns an owned, reference-counting pointer to the second argument
+    /// passed to [`Server::new`].
+    ///
+    /// [`Server::new`]: crate::Server::new
     pub fn app_owned(&self) -> Shared<App> {
         self.app.clone()
     }

--- a/via/src/router/mod.rs
+++ b/via/src/router/mod.rs
@@ -3,21 +3,21 @@
 mod route;
 mod switch;
 
-pub use route::Route;
+pub use route::{Prefix, Route};
 pub use switch::*;
 
 pub(crate) use switch::MethodNotAllowed;
 
 use std::sync::Arc;
-use via_router::Traverse;
+use via_router::{Router as Trie, Traverse};
 
 use crate::middleware::Middleware;
 
-pub(crate) struct Router<App> {
-    tree: via_router::Router<Arc<dyn Middleware<App>>>,
+pub struct Router<App> {
+    trie: Trie<Arc<dyn Middleware<App>>>,
 }
 
-/// Returns a partially applied function that attaches `middleware` to a route.
+/// Returns a partially applied function that attaches `middleware` to a path.
 ///
 /// This is intended to be used with [`Route::map`], allowing middleware to be
 /// composed into a route without having to write a closure.
@@ -25,25 +25,23 @@ pub(crate) struct Router<App> {
 /// # Example
 ///
 /// ```
-/// // Create a new application.
-/// let mut app = via::app(());
+/// # via::Router::new(|home| {
+/// # let mut path = home.prefix();
+/// // Define the /api namespace.
+/// let mut api = path.push("/api");
 ///
-/// // Define the /api namespace
-/// let mut path = app.push("/api");
+/// // Start defining descendants of "/api".
+/// let mut path = api.prefix();
 ///
-/// // Define the /api/auth namespace.
+/// // Define the /api/auth resource.
 /// path.route("/auth", via::post(login).delete(logout))
-///     //                        ^^^^^         ^^^^^^
-///     //
-///     // The `login` and `logout` middleware both terminate the
-///     // request.
-///     //
-///     // Therefore, `authenticate` can safely be applied after
-///     // them without changing their behavior.
+///     // Continue defining the /api/auth resource from /api/auth/me.
+///     .push("/me")
+///     // Requests to /api/auth/me require an authenticated user.
 ///     .map(via::router::apply(authenticate))
-///     // Requests to "/api/auth/me" or any descendant of "/auth"
-///     // require an authenticated user.
-///     .route("/me", via::get(me));
+///     // GET /api/auth/me responds with the active user as JSON.
+///     .assign(via::get(me));
+/// # });
 /// #
 /// # async fn authenticate(_: via::Request, _: via::Next) -> via::Result { unimplemented!() }
 /// # async fn login(_: via::Request, _: via::Next) -> via::Result { unimplemented!() }
@@ -61,33 +59,15 @@ where
 }
 
 impl<App> Router<App> {
-    pub fn new() -> Self {
-        Self {
-            tree: via_router::Router::new(),
-        }
+    pub fn new(router: impl FnOnce(Route<'_, App>)) -> Self {
+        let mut trie = via_router::Router::new();
+        let node = trie.route("/");
+
+        router(Route { node });
+        Self { trie }
     }
 
-    pub fn middleware<T>(&mut self, middleware: T)
-    where
-        T: Middleware<App> + 'static,
-    {
-        self.tree.middleware(Arc::new(middleware))
-    }
-
-    pub fn push(&mut self, path: &'static str) -> Route<'_, App> {
-        Route {
-            node: self.tree.route(path),
-        }
-    }
-
-    pub fn route<T>(&mut self, path: &'static str, middleware: T) -> Route<'_, App>
-    where
-        T: Middleware<App> + 'static,
-    {
-        self.push(path).assign(middleware)
-    }
-
-    pub fn traverse<'b>(&self, path: &'b str) -> Traverse<'_, 'b, Arc<dyn Middleware<App>>> {
-        self.tree.traverse(path)
+    pub(crate) fn traverse<'b>(&self, path: &'b str) -> Traverse<'_, 'b, Arc<dyn Middleware<App>>> {
+        self.trie.traverse(path)
     }
 }

--- a/via/src/router/route.rs
+++ b/via/src/router/route.rs
@@ -3,7 +3,12 @@ use via_router::RouteMut;
 
 use crate::middleware::Middleware;
 
-/// An entry in the route tree associated with a path segment pattern.
+/// A route prefix from which descenants can be defined.
+pub struct Prefix<'a, App = ()> {
+    node: RouteMut<'a, Arc<dyn Middleware<App>>>,
+}
+
+/// A vacant entry in the route tree associated with a path segment pattern.
 ///
 /// Route definitions are composable and inherit middleware from their
 /// ancestors. The order in which routes and their middleware are defined
@@ -18,66 +23,37 @@ use crate::middleware::Middleware;
 ///
 /// ```no_run
 /// use std::process::ExitCode;
-/// use via::{Error, Next, Request, Server, rescue};
+/// use via::{Next, Request, Router, Server, rescue};
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<ExitCode, Error> {
-///     let mut app = via::app(());
-///     let mut path = app.push("/api");
+/// async fn main() -> via::Result<ExitCode> {
+///     let router = Router::new(|mut home| {
+///         let mut path = home.prefix();
+///         let mut api = path.push("/api");
 ///
-///     // If an error occurs on a descendant of /api, respond with json.
-///     // Siblings of /api must define their own error handling logic.
-///     path.middleware(rescue::json().build());
+///         // If an error occurs on a descendant of /api, respond with json.
+///         // Siblings of /api must define their own error handling logic.
+///         api.middleware(rescue::json().build());
 ///
-///     // Define a /users resource as a child of /api so the rescue and timeout
-///     // middleware run before any of the middleware or responders defined in
-///     // the /users resource.
-///     path.route("/users", via::get(async |_, _| todo!()))
-///         .route("/:user-id", via::get(async |_, _| todo!()));
+///         // Start defining descendants of /api.
+///         let mut path = api.prefix();
+///
+///         // Define a /users resource as a child of /api so the rescue and
+///         // timeout middleware run before any of the middleware or
+///         // responders defined in the /users resource.
+///         path.route("/users", via::get(async |_, _| todo!()))
+///             .route("/:user-id", via::get(async |_, _| todo!()));
+///     });
 ///
 ///     // Start serving our application from http://localhost:8080/.
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
-pub struct Route<'a, App> {
+pub struct Route<'a, App = ()> {
     pub(super) node: RouteMut<'a, Arc<dyn Middleware<App>>>,
 }
 
-impl<'a, App> Route<'a, App> {
-    /// Appends the provided middleware to the route's call stack.
-    ///
-    /// Middleware attached to a route runs anytime the route’s path is a
-    /// prefix of the request path.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use via::{Next, Request, cookies, deny};
-    /// # let mut app = via::app(());
-    /// #
-    /// // Provides application-wide support for request and response cookies.
-    /// app.middleware(cookies(["is-admin"]));
-    ///
-    /// // Requests made to /admin or any of its descendants must have an
-    /// // is-admin cookie present on the request.
-    /// app.push("/admin").middleware(async |request: Request, next: Next| {
-    ///     // We suggest using signed cookies to prevent tampering.
-    ///     // See the cookies example in our git repo for more information.
-    ///     if request.cookies().get("is-admin").is_none() {
-    ///         deny!(401);
-    ///     }
-    ///
-    ///     next.call(request).await
-    /// });
-    /// ```
-    ///
-    pub fn middleware<T>(&mut self, middleware: T)
-    where
-        T: Middleware<App> + 'static,
-    {
-        self.node.middleware(Arc::new(middleware));
-    }
-
+impl<'a, App> Prefix<'a, App> {
     /// Returns a new child route by appending the provided path to the current
     /// route.
     ///
@@ -87,11 +63,10 @@ impl<'a, App> Route<'a, App> {
     /// # Example
     ///
     /// ```
-    /// # let mut app = via::app(());
-    /// // The following routes all reference the same path: /hello/:name.
-    /// app.push("/hello/:name");
-    /// app.push("hello").push(":name");
-    /// app.push("/hello").push("/:name");
+    /// # via::Router::<()>::new(|home| {
+    /// # let mut path = home.prefix();
+    /// path.push("/hello/:name");
+    /// # });
     /// ```
     ///
     /// # Dynamic Segments
@@ -110,35 +85,6 @@ impl<'a, App> Route<'a, App> {
     ///
     /// Dynamic segments match any path segment, so define them after all
     /// static sibling routes to ensure intended routing behavior.
-    ///
-    /// Consider the following sequence of route definitions. We define
-    /// `/articles/trending` before `/articles/:id` to ensure that a request to
-    /// `/articles/trending` is routed to `articles::trending` rather than
-    /// capturing `"trending"` as `id` and invoking `articles::show`.
-    ///
-    /// ```
-    /// # let mut app = via::app(());
-    /// let mut path = app.push("/posts");
-    ///
-    /// // Assigning a terminal middleware to a path takes ownership of self.
-    /// //
-    /// // We want to continue defining adjacent resources rather than
-    /// // dependencies of an individual post. Therefore, we reassign path.
-    /// path = path.assign(via::get(posts::index));
-    ///
-    /// // The /posts/:id resource.
-    /// path.push("/:id").assign(via::get(posts::show));
-    ///
-    /// // A bespoke /posts/trending route.
-    /// path.push("/trending").assign(via::get(posts::trending));
-    /// #
-    /// # mod posts {
-    /// #     use via::{Next, Request};
-    /// #     pub async fn trending(_: Request, _: Next) -> via::Result { todo!() }
-    /// #     pub async fn index(_: Request, _: Next) -> via::Result { todo!() }
-    /// #     pub async fn show(_: Request, _: Next) -> via::Result { todo!() }
-    /// # }
-    /// ```
     pub fn push(&mut self, path: &'static str) -> Route<'_, App> {
         Route {
             node: self.node.route(path),
@@ -151,17 +97,18 @@ impl<'a, App> Route<'a, App> {
     /// # Example
     ///
     /// ```
-    /// # let mut app = via::app(());
-    /// let mut path = app.push("/posts");
+    /// # via::Router::new(|home| {
+    /// #   let mut path = home.prefix();
+    /// #
+    ///     // The /posts "collection" resource.
+    ///     let mut posts = path.route("/posts", via::get(posts::index));
     ///
-    /// // The /posts "collection" resource.
-    /// path = path.assign(via::get(posts::index));
+    ///     // A bespoke /posts/trending route.
+    ///     posts.route("/trending", via::get(posts::trending));
     ///
-    /// // The /posts/:id "member" resource.
-    /// path.route("/:id", via::get(posts::show));
-    ///
-    /// // A bespoke /posts/trending route.
-    /// path.route("/trending", via::get(posts::trending));
+    ///     // The /posts/:id "member" resource.
+    ///     posts.route("/:id", via::get(posts::show));
+    /// # });
     /// #
     /// # mod posts {
     /// #     use via::{Next, Request};
@@ -170,11 +117,57 @@ impl<'a, App> Route<'a, App> {
     /// #     pub async fn show(_: Request, _: Next) -> via::Result { todo!() }
     /// # }
     /// ```
-    pub fn route<T>(&mut self, path: &'static str, middleware: T) -> Route<'_, App>
+    pub fn route<T>(&mut self, path: &'static str, middleware: T) -> Prefix<'_, App>
     where
         T: Middleware<App> + 'static,
     {
         self.push(path).assign(middleware)
+    }
+
+    /// Takes ownership of self and then calls `op` with a mutable ref to self.
+    pub fn map<T>(self, op: impl FnOnce(Self) -> T) -> T {
+        op(self)
+    }
+}
+
+impl<'a, App> Route<'a, App> {
+    /// Appends the provided middleware to the route's call stack.
+    ///
+    /// Middleware attached to a route runs anytime the route’s path is a
+    /// prefix of the request path.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use via::{Next, Request, Route, cookies, deny};
+    /// # via::Router::new(|mut home| {
+    /// // Provides application-wide support for request and response cookies.
+    /// home.middleware(cookies(["is-admin"]));
+    ///
+    /// // Start defining descendants of "/".
+    /// let mut path = home.prefix();
+    ///
+    /// // The /admin namespace.
+    /// let mut admin = path.push("/admin");
+    ///
+    /// // Requests made to /admin or any of its descendants must have an
+    /// // is-admin cookie present on the request.
+    /// admin.middleware(async |request: Request, next: Next| {
+    ///     // We suggest using signed cookies to prevent tampering.
+    ///     // See the cookies example in our git repo for more information.
+    ///     if request.cookies().get("is-admin").is_none() {
+    ///         deny!(401);
+    ///     }
+    ///
+    ///     next.call(request).await
+    /// });
+    /// # });
+    /// ```
+    pub fn middleware<T>(&mut self, middleware: T)
+    where
+        T: Middleware<App> + 'static,
+    {
+        self.node.middleware(Arc::new(middleware));
     }
 
     /// Defines how the route should respond when it is visited.
@@ -182,20 +175,25 @@ impl<'a, App> Route<'a, App> {
     /// # Example
     ///
     /// ```
-    /// # let mut app = via::app(());
+    /// # use via::router::Route;
     /// #
-    /// // Define the /users resource as `path`.
-    /// let mut path = app.push("/users");
+    /// # via::Router::new(|home| {
+    /// # let mut path = home.prefix();
+    /// // The /users resource.
+    /// let mut users = path.push("/users");
     ///
-    /// path.assign(via::get(users::index))
-    /// //          ^^^^^^^^^^^^^^^^^^^^^
-    /// //   Called only when the request path matches /users.
-    /// //
-    ///     .push("/:id")
-    ///     .assign(via::get(users::show));
+    /// // Redefine path as the /users prefix.
+    /// let mut path = users.assign(via::get(users::index));
+    /// //                          ^^^^^^^^^^^^^^^^^^^^^
+    /// // Called only when the request path matches /users.
+    ///
+    /// // The /users/:user-id resource.
+    /// let mut user = path.push("/:user-id");
+    ///
+    /// user.assign(via::get(users::index));
     /// //          ^^^^^^^^^^^^^^^^^^^^^
     /// //   Called only when the request path matches /users/:id.
-    /// //
+    /// # });
     /// #
     /// # mod users {
     /// #     use via::{Next, Request};
@@ -203,44 +201,22 @@ impl<'a, App> Route<'a, App> {
     /// #     pub async fn show(_: Request, _: Next) -> via::Result { todo!() }
     /// # }
     /// ```
-    pub fn assign<T>(self, middleware: T) -> Self
+    pub fn assign<T>(self, middleware: T) -> Prefix<'a, App>
     where
         T: Middleware<App> + 'static,
     {
-        Self {
+        Prefix {
             node: self.node.assign(Arc::new(middleware)),
         }
     }
 
     /// Takes ownership of self and then calls `op` with a mutable ref to self.
-    ///
-    /// Maping a route is particularly useful when you want to define routes in
-    /// a new scope. It is less busy than assigning the path to a variable in a
-    /// block.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let mut app = via::app(());
-    /// #
-    /// // The /posts "collection" resource.
-    /// app.route("/posts", via::get(posts::index)).map(|mut path| {
-    ///     // The /posts/:id "member" resource.
-    ///     path.route("/:post-id", via::get(posts::show));
-    ///
-    ///     // A bespoke /posts/trending route.
-    ///     path.route("/:post-id", via::get(posts::trending));
-    /// });
-    /// #
-    /// # mod posts {
-    /// #     use via::{Next, Request};
-    /// #     pub async fn trending(_: Request, _: Next) -> via::Result { todo!() }
-    /// #     pub async fn index(_: Request, _: Next) -> via::Result { todo!() }
-    /// #     pub async fn show(_: Request, _: Next) -> via::Result { todo!() }
-    /// # }
-    /// ```
-    ///
     pub fn map<T>(self, op: impl FnOnce(Self) -> T) -> T {
         op(self)
+    }
+
+    /// Returns a prefix from which descendant routes can be defined.
+    pub fn prefix(self) -> Prefix<'a, App> {
+        Prefix { node: self.node }
     }
 }

--- a/via/src/router/switch.rs
+++ b/via/src/router/switch.rs
@@ -29,7 +29,7 @@ pub struct Deny {
 /// ```no_run
 /// use http::Method;
 /// use std::process::ExitCode;
-/// use via::{Error, Next, Request, Response, ResultExt, Server};
+/// use via::{Next, Request, Response, ResultExt, Router, Server};
 ///
 /// async fn update(request: Request, _: Next) -> via::Result {
 ///     let id = request.param("user-id").parse::<u64>().or_bad_request()?;
@@ -46,17 +46,20 @@ pub struct Deny {
 /// }
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<ExitCode, Error> {
-///     let mut app = via::app(());
+/// async fn main() -> via::Result<ExitCode> {
+///     let router = Router::new(|home| {
+///         // Start defining descendants of "/".
+///         let mut path = home.prefix();
 ///
-///     // The route "/users/:user-id" accepts PATCH and PUT requests.
-///     app.push("/users/:user-id").assign(
-///         via::patch(update)
-///             .put(update)
-///             .or_deny(), // All other methods are a 405 Method Not Allowed.
-///     );
+///         // The route "/users/:user-id" accepts PATCH and PUT requests.
+///         path.push("/users/:user-id").assign(
+///             via::patch(update)
+///                 .put(update)
+///                 .or_deny(), // All other methods are a 405 Method Not Allowed.
+///         );
+///     });
 ///
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 /// ```
 pub struct Switch<T, U> {
@@ -153,7 +156,7 @@ impl<T, U> Switch<T, U> {
     /// # Example
     ///
     /// ```
-    /// # use via::{Next, Request, Response, ResultExt};
+    /// # use via::{Next, Request, Response, ResultExt, Route};
     /// #
     /// # async fn greet(request: Request, _: Next) -> via::Result {
     /// #   let name = request.param("name").into_result()?;
@@ -161,10 +164,12 @@ impl<T, U> Switch<T, U> {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut app = via::app(());
-    /// app.route("/hello/:name", via::get(greet).or_deny());
+    /// # via::Router::new(|home| {
+    /// # let mut path = home.prefix();
+    /// path.route("/hello/:name", via::get(greet).or_deny());
     /// // curl -XPOST http://localhost:8080/hello/world
     /// // => method not allowed: "POST"
+    /// # });
     /// # }
     /// ```
     ///

--- a/via/src/server/mod.rs
+++ b/via/src/server/mod.rs
@@ -12,6 +12,7 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 
 use crate::app::{ServiceAdapter, Via};
 use crate::error::Error;
+use crate::router::Router;
 
 use accept::accept;
 use tls::TcpAcceptor;
@@ -72,10 +73,10 @@ impl<App> Server<App>
 where
     App: Send + Sync + 'static,
 {
-    /// Creates a new server for the provided app.
-    pub fn new(app: Via<App>) -> Self {
+    /// Create a new server for `router` and `app`.
+    pub fn new(router: Router<App>, app: App) -> Self {
         Self {
-            app,
+            app: Via::new(router, app),
             config: Default::default(),
         }
     }

--- a/via/src/ws/mod.rs
+++ b/via/src/ws/mod.rs
@@ -28,7 +28,7 @@ pub use upgrade::Ws;
 /// ```no_run
 /// use std::process::ExitCode;
 /// use via::ws::{self, Channel, Message};
-/// use via::{Error, Server};
+/// use via::{Error, Router, Server};
 ///
 /// async fn echo(mut channel: Channel, _: ws::Request) -> ws::Result {
 ///     while let Some(message) = channel.recv().await {
@@ -49,15 +49,18 @@ pub use upgrade::Ws;
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<ExitCode, Error> {
-///     let mut app = via::app(());
+///     let router = Router::new(|home| {
+///         // Start defining the descendats of "/".
+///         let mut path = home.prefix();
 ///
-///     // GET /echo ~> web socket upgrade.
-///     app.route("/echo", via::get(via::ws(echo)).or_deny());
+///         // GET /echo ~> web socket upgrade.
+///         path.route("/echo", via::get(via::ws(echo)).or_deny());
+///     });
 ///
-///     Server::new(app).listen(("127.0.0.1", 8080)).await
+///     // Start listening at http://localhost:8080/ for incoming requests.
+///     Server::new(router, ()).listen(("127.0.0.1", 8080)).await
 /// }
 ///```
-///
 pub fn ws<T, App, Await>(listener: T) -> Ws<T>
 where
     T: Fn(Channel, Request<App>) -> Await,


### PR DESCRIPTION
Enforces router DSL correctness by requiring routes to define middleware before defining descendants or assigning a terminal middleware ("responder").

This change requires that the router be constructed separately from the application in order to properly support middleware and terminal middleware at the application root "/".

The result is actually pretty nice considering that it cleanly separates DI from route definitions. It also allows routes to be defined before setting up application dependencies.It's a best practice to connect to the database as late as possible but just before the server starts accepting connections.

The chat app will be update immediately so everyone has an example to follow. These are last minute growing pains right before a major release.