### PR TITLE
fix(via-macros): target patch, post, or put in content!

### DIFF
--- a/via-macros/Cargo.toml
+++ b/via-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-macros"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["Zakari Papa <pino@hey.com>"]
 license = "MIT OR Apache-2.0"

--- a/via-macros/src/guard.rs
+++ b/via-macros/src/guard.rs
@@ -43,11 +43,11 @@
 macro_rules! content {
     ($accepts:expr, $provides:expr) => {
         via::guard::if_else(
-            via::guard::on::method((
+            via::guard::on::method(via::guard::or((
                 via::guard::method::patch(),
                 via::guard::method::post(),
                 via::guard::method::put(),
-            )),
+            ))),
             via::guard::on::headers((
                 via::guard::header::accept($provides),
                 via::guard::header::content_type($accepts),

--- a/via-macros/src/guard.rs
+++ b/via-macros/src/guard.rs
@@ -43,7 +43,11 @@
 macro_rules! content {
     ($accepts:expr, $provides:expr) => {
         via::guard::if_else(
-            via::guard::method::is_mutation(),
+            via::guard::on::method((
+                via::guard::method::patch(),
+                via::guard::method::post(),
+                via::guard::method::put(),
+            )),
             via::guard::on::headers((
                 via::guard::header::accept($provides),
                 via::guard::header::content_type($accepts),

--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1"
 smallvec = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tokio-websockets = { version = "0.13", features = ["ring", "server"], optional = true }
-via-macros = { path = "../via-macros", version = "0.2" }
+via-macros = { path = "../via-macros", version = "1" }
 via-router = { path = "../via-router", version = "3.0.0-beta.35" }
 zeroize = "1"
 


### PR DESCRIPTION
Updates the `content!` macro to only validate the content-type and content-length headers for requests that are known to have a body.