### PR TITLE
feat(via): simplify resource usage config

### DIFF
--- a/examples/files/main.rs
+++ b/examples/files/main.rs
@@ -4,19 +4,6 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use via::{Error, Next, Request, Router, Server};
 
-/// The maximum number of connections we are willing to accept before
-/// accounting for resources other than TCP connections.
-const MAX_CONNECTIONS: usize = 1024;
-
-/// The number of file descriptors required for the multi-threaded tokio
-/// runtime, a graceful shutdown signal, and a tcp listener.
-///
-/// This is used to provide padding for the runtime so we can deterministically
-/// calculate the number of file descriptors required for the server to never
-/// trigger an EMFILE.
-#[cfg(unix)]
-const RT_FD_REQUIREMENT: usize = 13;
-
 #[cfg_attr(not(feature = "fs"), allow(dead_code))]
 struct Bubblegum {
     /// The directory from which files can be served.
@@ -44,27 +31,6 @@ impl Bubblegum {
 
     fn semaphore(&self) -> &Arc<Semaphore> {
         &self.semaphore
-    }
-}
-
-/// Calculates how many files can be open concurrently and returns it along
-/// with the adjusted maximum number of connections.
-fn determine_resource_usage() -> via::Result<(usize, usize)> {
-    cfg_select! {
-        // On Windows, sockets are not files.
-        windows => Ok((MAX_CONNECTIONS.div_ceil(2), MAX_CONNECTIONS)),
-
-        // On POSIX, max_concurrency affects the max_connections budget.
-        //
-        // The default amount of padding provided by Via is 13. The maximum
-        // amount of concurrent file streams should not exceed the number of
-        // worker process in the tokio runtime.
-        _ => {{
-            let concurrency = std::thread::available_parallelism()?.get();
-            let adjusted_max = MAX_CONNECTIONS - RT_FD_REQUIREMENT - concurrency;
-
-            Ok((concurrency, adjusted_max))
-        }}
     }
 }
 
@@ -132,11 +98,11 @@ async fn main() -> Result<ExitCode, Error> {
     });
 
     // Setup our file serving application.
-    let (max_open_files, max_connections) = determine_resource_usage()?;
+    let max_open_files = std::thread::available_parallelism()?.get();
     let bubblegum = Bubblegum::new(max_open_files);
 
     Server::new(router, bubblegum)
-        .max_connections(max_connections)
+        .reserve_file_descriptors(max_open_files)
         .listen(("127.0.0.1", 8080))
         .await
 }

--- a/via/src/server/mod.rs
+++ b/via/src/server/mod.rs
@@ -154,28 +154,6 @@ where
         self
     }
 
-    /// Reserve the exact number of file descriptors used in your application.
-    ///
-    /// Determinism is the backbone of high assurance.
-    ///
-    /// If you know the exact number of resources your application uses, set
-    /// this value to ensure the exact amount of backpressure is applied in
-    /// accept.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `len` is >= to the maximum number of connections.
-    pub fn reserve_file_descriptors(mut self, len: usize) -> Self {
-        assert!(
-            len < self.config.max_connections,
-            "reserved fd len must be < max_connections ({})",
-            self.config.max_connections,
-        );
-
-        self.config.max_connections -= len;
-        self
-    }
-
     /// Set the maximum request body size in bytes.
     ///
     /// **Default:** `100 MB`

--- a/via/src/server/mod.rs
+++ b/via/src/server/mod.rs
@@ -43,6 +43,9 @@ pub(crate) type IoStream = io::IoWithPermit<tls::RustlsStream>;
 ))]
 pub(crate) type IoStream = io::IoWithPermit<tokio::net::TcpStream>;
 
+const DEFAULT_MAX_CONNECTIONS: usize = 1024;
+const RUNTIME_FD_BUDGET: usize = 10;
+
 /// Serve an app over HTTP.
 ///
 pub struct Server<App> {
@@ -112,9 +115,42 @@ where
     /// Sets the maximum number of concurrent connections that the server can
     /// accept.
     ///
-    /// **Default:** `1000`
+    /// An idle Via application uses 10 file descriptors on POSIX platforms.
+    ///
+    /// Rather than making you do math for no reason, we subtract 10 from the
+    /// provided connection budget.
+    ///
+    /// **Default:** `1024`
     pub fn max_connections(mut self, max_connections: usize) -> Self {
-        self.config.max_connections = max_connections;
+        assert!(
+            max_connections > RUNTIME_FD_BUDGET,
+            "max_connections must be > {}",
+            RUNTIME_FD_BUDGET,
+        );
+
+        self.config.max_connections = max_connections - RUNTIME_FD_BUDGET;
+        self
+    }
+
+    /// Reserve the exact number of file descriptors used in your application.
+    ///
+    /// Determinism is the backbone of high assurance.
+    ///
+    /// If you know the exact number of resources your application uses, set
+    /// this value to ensure the exact amount of backpressure is applied in
+    /// accept.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` is >= to the maximum number of connections.
+    pub fn reserve_file_descriptors(mut self, len: usize) -> Self {
+        assert!(
+            len < self.config.max_connections,
+            "reserved fd len must be < max_connections ({})",
+            self.config.max_connections,
+        );
+
+        self.config.max_connections -= len;
         self
     }
 
@@ -368,7 +404,7 @@ impl Default for ServerConfig {
         Self {
             keep_alive: true,
             max_buf_size: 16384, // 16 KB
-            max_connections: 1000,
+            max_connections: DEFAULT_MAX_CONNECTIONS - RUNTIME_FD_BUDGET,
             max_request_size: 104_857_600, // 100 MB
             shutdown_timeout: Duration::from_secs(10),
             http1_header_read_timeout: Duration::from_secs(10),


### PR DESCRIPTION
Simplifies the resource usage config so users of Via only have to calculate what they use in addition to the maximum number of connections. In combination with #616, we should be able to never trigger an EMFILE while also keeping the kernel backlog empty.