### PR TITLE
fix(via): fix unused variable warnings in release

### DIFF
--- a/via/src/before.rs
+++ b/via/src/before.rs
@@ -211,6 +211,14 @@ where
         match (self.decorator)(&mut request) {
             Ok(_) => self.middleware.call(request, next),
             Err(ControlFlow::Break(error)) => Box::pin(async { Err(error) }),
+
+            // In release builds, the error is not logged.
+            // Therefore, we branch at build-time on the match arm.
+            //
+            #[cfg(not(debug_assertions))]
+            Err(ControlFlow::Continue(_)) => next.call(request),
+
+            #[cfg(debug_assertions)]
             Err(ControlFlow::Continue(error)) => {
                 log!(warn(before = 0), "{}", &error);
                 next.call(request)

--- a/via/src/error/rescue.rs
+++ b/via/src/error/rescue.rs
@@ -241,13 +241,22 @@ where
             future.await.or_else(|error| {
                 let flags = policy.apply(&error, PolicyFlags::new());
 
-                Render::new(&flags.mask, &error)
-                    .finalize(Response::build())
-                    .or_else(|residual| {
+                match Render::new(&flags.mask, &error).finalize(Response::build()) {
+                    Ok(response) => Ok(response),
+
+                    // In release builds, residual errors are not logged.
+                    // Therefore, we branch at build-time on the match arm.
+                    //
+                    #[cfg(not(debug_assertions))]
+                    Err(_) => Ok(error.into()),
+
+                    #[cfg(debug_assertions)]
+                    Err(residual) => {
                         log!(warn(rescue = 0), "a residual error occurred in rescue");
                         log!(warn(rescue = 1), "{}", &residual);
                         Ok(error.into())
-                    })
+                    }
+                }
             })
         })
     }

--- a/via/src/lib.rs
+++ b/via/src/lib.rs
@@ -51,14 +51,19 @@
 //!
 
 macro_rules! log {
-    ($level:tt($name:ident = $indent:expr), $fmt:literal $($arg:tt)*) => {
+    ($level:tt($name:ident = $indent:expr), $fmt:literal $(, $($arg:expr)*)?) => {
+        $($(
+            #[cfg(not(debug_assertions))]
+            let _ = $arg;
+        )*)?
+
         #[cfg(debug_assertions)]
         eprintln!(
             "{:indent$}{}({}): {}",
             "",
             stringify!($level),
             stringify!($name),
-            format_args!($fmt $($arg)*),
+            format_args!($fmt $(, $($arg),*)?),
             indent = $indent * 2,
         );
     };


### PR DESCRIPTION
Fixes the unused variables warning by branching with cfg args at build-time.

We are a high assurance web framework. We care about trust boundaries and how every variable is used.

This is rare enough to handle at the call site. A formal pattern can be established when we integrate tracing as a feature flag.