### PR TITLE
feat(via-diesel): bring via-diesel into the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "3"
-members = ["examples", "via", "via-macros", "via-router"]
+members = ["examples", "via", "via-diesel", "via-macros", "via-router"]

--- a/via-diesel/Cargo.toml
+++ b/via-diesel/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "via-diesel"
+version = "0.1.0-beta.1"
+authors = ["Zakari Papa <pino@hey.com>"]
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "An async diesel integration for Via built on top of diesel-async."
+homepage = "https://github.com/via-rs/via-diesel"
+repository = "https://github.com/via-rs/via-diesel"
+
+[dependencies]
+diesel-async = "0.9"
+diesel = "2"
+http = "1"
+via = { path = "../via", version = "=2.0.0-gm.59" }

--- a/via-diesel/Cargo.toml
+++ b/via-diesel/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "via-diesel"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "An async diesel integration for Via built on top of diesel-async."
-homepage = "https://github.com/via-rs/via-diesel"
-repository = "https://github.com/via-rs/via-diesel"
+homepage = "https://github.com/via-rs/via"
+repository = "https://github.com/via-rs/via"
 
 [dependencies]
 diesel-async = "0.9"

--- a/via-diesel/LICENSE-APACHE
+++ b/via-diesel/LICENSE-APACHE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Zachary Golba
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/via-diesel/LICENSE-MIT
+++ b/via-diesel/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2024 Zachary Golba
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/via-diesel/README.md
+++ b/via-diesel/README.md
@@ -1,0 +1,12 @@
+# Via Diesel
+
+A pre-release async diesel integration for [Via](https://github.com/via-rs/via).
+
+## License
+
+Licensed under either of
+
+-   Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+-   MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.

--- a/via-diesel/src/lib.rs
+++ b/via-diesel/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod prelude;
+
+mod macros;
+mod paginate;
+mod query_dsl;
+
+pub use paginate::{LimitAndOffset, LimitAndPage};
+pub use query_dsl::AsyncQueryDsl;

--- a/via-diesel/src/lib.rs
+++ b/via-diesel/src/lib.rs
@@ -1,8 +1,6 @@
-pub mod prelude;
-
 mod macros;
 mod paginate;
 mod query_dsl;
 
-pub use paginate::{LimitAndOffset, LimitAndPage};
+pub use paginate::{LimitAndOffset, LimitAndPage, Paginate};
 pub use query_dsl::AsyncQueryDsl;

--- a/via-diesel/src/macros.rs
+++ b/via-diesel/src/macros.rs
@@ -1,0 +1,69 @@
+// /// Generate filters from expressions that work with the diesel query dsl.
+#[macro_export]
+macro_rules! filters {
+    (#[output] ==, $lhs:ty, $rhs:ty) => { diesel::dsl::Eq<$lhs, $rhs> };
+    (#[expr] ==, $lhs:expr, $rhs:expr) => { $lhs.eq($rhs) };
+
+    (#[output] !=, $lhs:ty, $rhs:ty) => { diesel::dsl::Ne<$lhs, $rhs> };
+    (#[expr] !=, $lhs:expr, $rhs:expr) => { $lhs.ne($rhs) };
+
+    (#[output] >,  $lhs:ty,   $rhs:ty) => { diesel::dsl::Gt<$lhs, $rhs> };
+    (#[expr] >,   $lhs:expr, $rhs:expr) => { $lhs.gt($rhs) };
+
+    (#[output] >=, $lhs:ty,   $rhs:ty) => { diesel::dsl::GtEq<$lhs, $rhs> };
+    (#[expr] >=,  $lhs:expr, $rhs:expr) => { $lhs.ge($rhs) };
+
+    (#[output] <,  $lhs:ty,   $rhs:ty) => { diesel::dsl::Lt<$lhs, $rhs> };
+    (#[expr] <,   $lhs:expr, $rhs:expr) => { $lhs.lt($rhs) };
+
+    (#[output] <=, $lhs:ty,   $rhs:ty) => { diesel::dsl::LtEq<$lhs, $rhs> };
+    (#[expr] <=,  $lhs:expr, $rhs:expr) => { $lhs.le($rhs) };
+
+    (#[output] <=, $lhs:ty,   $rhs:ty) => { diesel::dsl::LtEq<$lhs, $rhs> };
+    (#[expr] <=,  $lhs:expr, $rhs:expr) => { $lhs.le($rhs) };
+
+    (#[output] is_null, $lhs:ty) => { diesel::dsl::IsNull<$lhs> };
+    (#[expr] is_null,  $lhs:expr) => { $lhs.is_null() };
+
+    ($($vis:vis fn $by:ident($column:ident $op:tt $($ty:ty)?) on $table:ident);+ $(;)?) => {
+        $($vis fn $by($(value: $ty)?) -> $crate::filters!(#[output] $op, $table::$column $(, $ty)?) {
+            $crate::filters!(#[expr] $op, $table::$column $(, value as $ty)?)
+        })+
+    };
+}
+
+/// Generate sort scopes from a tuple of columns that can be used to order
+/// results returned from the diesel query dsl.
+///
+/// Scopes should correspond to an index in the database.
+///
+/// For each scope defined, we generate a function that returns the tuple of
+/// sort expressions and a module with the same name as the function. The
+/// module exports a `columns` constant that can be used to reference the
+/// columns returned from the sort scope when grouping results or filtering
+/// before or after a keyset.
+#[macro_export]
+macro_rules! sorts {
+    (#[output(desc)] $column:ty) => { diesel::dsl::Desc<$column> };
+    (#[expr(desc)] $column:expr) => { $column.desc() };
+
+    (#[output($(asc)?)] $column:ty) => { $column };
+    (#[expr($(asc)?)] $column:expr) => { $column };
+
+    (
+        $($vis:vis fn $by:ident($($(#[$direction:tt])? $column:ident),+) on $table:ident);+
+        $(;)?
+    ) => {
+        $(
+            $vis fn $by() -> ($($crate::sorts!(#[output($($direction)?)] $table::$column)),+) {
+                ($($crate::sorts!(#[expr($($direction)?)] $table::$column)),+)
+            }
+
+            $vis mod $by {
+                use super::$table::{$($column),+};
+                #[allow(dead_code, non_upper_case_globals)]
+                pub const columns: ($($column),+) = ($($column),+);
+            }
+        )+
+    };
+}

--- a/via-diesel/src/paginate.rs
+++ b/via-diesel/src/paginate.rs
@@ -1,0 +1,91 @@
+use diesel::dsl::Offset;
+use diesel::query_dsl::methods::{LimitDsl, OffsetDsl};
+use via::request::params::{QueryParam, QueryParams};
+use via::{Error, ResultExt};
+
+const MIN_PER_PAGE: i64 = 5;
+const MAX_PER_PAGE: i64 = 100;
+
+pub trait Paginate<T> {
+    type Output;
+    fn page(self, cursor: T) -> Self::Output;
+}
+
+#[derive(Debug)]
+pub struct LimitAndOffset {
+    limit: i64,
+    offset: i64,
+}
+
+#[derive(Debug)]
+pub struct LimitAndPage {
+    limit_and_offset: LimitAndOffset,
+}
+
+fn map_or<F, T, E>(param: QueryParam, default: T, op: F) -> Result<T, Error>
+where
+    F: FnOnce(&str) -> Result<T, E>,
+    Error: From<E>,
+{
+    param.ok().and_then(|option| match option.as_deref() {
+        Some(value) => op(value).or_bad_request(),
+        None => Ok(default),
+    })
+}
+
+impl<T> Paginate<LimitAndOffset> for T
+where
+    T: LimitDsl,
+    <T as LimitDsl>::Output: OffsetDsl,
+{
+    type Output = Offset<<T as LimitDsl>::Output>;
+
+    fn page(self, cursor: LimitAndOffset) -> Self::Output {
+        self.limit(cursor.limit).offset(cursor.offset)
+    }
+}
+
+impl<T> Paginate<LimitAndPage> for T
+where
+    T: LimitDsl,
+    <T as LimitDsl>::Output: OffsetDsl,
+{
+    type Output = Offset<<T as LimitDsl>::Output>;
+
+    fn page(self, cursor: LimitAndPage) -> Self::Output {
+        self.page(cursor.limit_and_offset)
+    }
+}
+
+impl TryFrom<QueryParams<'_>> for LimitAndOffset {
+    type Error = via::Error;
+
+    fn try_from(query: QueryParams<'_>) -> via::Result<Self> {
+        let limit = map_or(query.first("limit"), MIN_PER_PAGE, str::parse)?;
+        let offset = map_or(query.first("offset"), 0, str::parse)?;
+
+        Ok(Self {
+            limit: limit.clamp(MIN_PER_PAGE, MAX_PER_PAGE),
+            offset: offset.max(0),
+        })
+    }
+}
+
+impl TryFrom<QueryParams<'_>> for LimitAndPage {
+    type Error = via::Error;
+
+    fn try_from(query: QueryParams<'_>) -> via::Result<Self> {
+        let page = map_or(query.first("page"), 1i64, str::parse)?;
+
+        if page < 1 {
+            via::deny!(400, "page must be a positive integer");
+        }
+
+        let limit = map_or(query.first("limit"), MIN_PER_PAGE, str::parse)?;
+        let offset = (page - 1).saturating_mul(limit);
+
+        Ok(Self {
+            limit_and_offset: LimitAndOffset { limit, offset },
+        })
+    }
+}

--- a/via-diesel/src/prelude.rs
+++ b/via-diesel/src/prelude.rs
@@ -1,0 +1,14 @@
+/// Reexports from the diesel prelude.
+pub use diesel::prelude::{
+    AggregateExpressionMethods, AppearsOnTable, AsChangeset, Associations, BelongingToDsl,
+    BoolExpressionMethods, BoxableExpression, Column, CombineDsl, Connection, DecoratableTarget,
+    EscapeExpressionMethods, Expression, ExpressionMethods, FrameBoundDsl, FrameClauseDsl,
+    FrameClauseEndBound, FrameClauseExclusion, FrameClauseStartBound, GroupedBy, HasQuery,
+    Identifiable, Insertable, IntoSql, JoinOnDsl, JoinTo, NullableExpressionMethods,
+    OffsetFollowing, OffsetPreceding, OptionalEmptyChangesetExtension, PreferredBoolSqlType,
+    QueryDsl, QuerySource, Queryable, QueryableByName, SaveChangesDsl, Selectable,
+    SelectableExpression, SelectableHelper, Table, TextExpressionMethods, WindowExpressionMethods,
+};
+
+pub use crate::paginate::Paginate;
+pub use crate::query_dsl::AsyncQueryDsl;

--- a/via-diesel/src/query_dsl.rs
+++ b/via-diesel/src/query_dsl.rs
@@ -11,7 +11,7 @@ use std::task::{Context, Poll};
 use via::err;
 
 pub trait AsyncQueryDsl<T>: Sized {
-    fn execute<'a, 'b>(self, connection: &'a mut T) -> MapErr<T::ExecuteFuture<'a, 'b>>
+    fn execute_async<'a, 'b>(self, connection: &'a mut T) -> MapErr<T::ExecuteFuture<'a, 'b>>
     where
         T: AsyncConnectionCore + Send,
         T::Backend: Default,
@@ -26,7 +26,10 @@ pub trait AsyncQueryDsl<T>: Sized {
         }
     }
 
-    fn first<'a, 'b, U>(self, connection: &'a mut T) -> MapErr<GetResult<'a, 'b, Limit<Self>, T, U>>
+    fn first_async<'a, 'b, U>(
+        self,
+        connection: &'a mut T,
+    ) -> MapErr<GetResult<'a, 'b, Limit<Self>, T, U>>
     where
         T: AsyncConnectionCore + Send,
         T::Backend: Default,
@@ -35,10 +38,10 @@ pub trait AsyncQueryDsl<T>: Sized {
         Self: diesel::query_dsl::methods::LimitDsl,
         Limit<Self>: LoadQuery<'b, T, U> + QueryFragment<T::Backend> + Send + 'b,
     {
-        AsyncQueryDsl::get_result(self.limit(1), connection)
+        AsyncQueryDsl::get_result_async(self.limit(1), connection)
     }
 
-    fn load<'a, 'b, U>(self, connection: &'a mut T) -> MapErr<LoadFuture<'a, 'b, Self, T, U>>
+    fn load_async<'a, 'b, U>(self, connection: &'a mut T) -> MapErr<LoadFuture<'a, 'b, Self, T, U>>
     where
         T: AsyncConnectionCore + Send,
         T::Backend: Default,
@@ -54,7 +57,10 @@ pub trait AsyncQueryDsl<T>: Sized {
         }
     }
 
-    fn get_result<'a, 'b, U>(self, connection: &'a mut T) -> MapErr<GetResult<'a, 'b, Self, T, U>>
+    fn get_result_async<'a, 'b, U>(
+        self,
+        connection: &'a mut T,
+    ) -> MapErr<GetResult<'a, 'b, Self, T, U>>
     where
         T: AsyncConnectionCore + Send,
         T::Backend: Default,

--- a/via-diesel/src/query_dsl.rs
+++ b/via-diesel/src/query_dsl.rs
@@ -1,0 +1,152 @@
+use diesel::backend::Backend;
+use diesel::dsl::Limit;
+use diesel::query_builder::QueryFragment;
+use diesel::result::{DatabaseErrorKind, Error as DieselError, QueryResult};
+use diesel_async::methods::{ExecuteDsl, LoadQuery};
+use diesel_async::return_futures::{GetResult, LoadFuture};
+use diesel_async::{AsyncConnectionCore, RunQueryDsl};
+use http::StatusCode;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use via::err;
+
+pub trait AsyncQueryDsl<T>: Sized {
+    fn execute<'a, 'b>(self, connection: &'a mut T) -> MapErr<T::ExecuteFuture<'a, 'b>>
+    where
+        T: AsyncConnectionCore + Send,
+        T::Backend: Default,
+        <T::Backend as Backend>::QueryBuilder: Default,
+        Self: ExecuteDsl<T> + QueryFragment<T::Backend> + 'b,
+    {
+        #[cfg(debug_assertions)]
+        debug_query(&self);
+
+        MapErr {
+            future: RunQueryDsl::execute(self, connection),
+        }
+    }
+
+    fn first<'a, 'b, U>(self, connection: &'a mut T) -> MapErr<GetResult<'a, 'b, Limit<Self>, T, U>>
+    where
+        T: AsyncConnectionCore + Send,
+        T::Backend: Default,
+        <T::Backend as Backend>::QueryBuilder: Default,
+        U: Send + 'a,
+        Self: diesel::query_dsl::methods::LimitDsl,
+        Limit<Self>: LoadQuery<'b, T, U> + QueryFragment<T::Backend> + Send + 'b,
+    {
+        AsyncQueryDsl::get_result(self.limit(1), connection)
+    }
+
+    fn load<'a, 'b, U>(self, connection: &'a mut T) -> MapErr<LoadFuture<'a, 'b, Self, T, U>>
+    where
+        T: AsyncConnectionCore + Send,
+        T::Backend: Default,
+        <T::Backend as Backend>::QueryBuilder: Default,
+        U: Send,
+        Self: LoadQuery<'b, T, U> + QueryFragment<T::Backend> + 'b,
+    {
+        #[cfg(debug_assertions)]
+        debug_query(&self);
+
+        MapErr {
+            future: RunQueryDsl::load(self, connection),
+        }
+    }
+
+    fn get_result<'a, 'b, U>(self, connection: &'a mut T) -> MapErr<GetResult<'a, 'b, Self, T, U>>
+    where
+        T: AsyncConnectionCore + Send,
+        T::Backend: Default,
+        <T::Backend as Backend>::QueryBuilder: Default,
+        U: Send + 'a,
+        Self: LoadQuery<'b, T, U> + QueryFragment<T::Backend> + Send + 'b,
+    {
+        #[cfg(debug_assertions)]
+        debug_query(&self);
+
+        MapErr {
+            future: RunQueryDsl::get_result(self, connection),
+        }
+    }
+}
+
+/// Convert errors occuring in a future returned by a query into an [`Error`].
+///
+/// [`Error`]: via::Error
+pub struct MapErr<F> {
+    future: F,
+}
+
+/// Prints the generated SQL query to the console in debug builds.
+#[cfg(debug_assertions)]
+fn debug_query<T, U>(query: &T)
+where
+    T: QueryFragment<U>,
+    U: Backend + Default,
+    U::QueryBuilder: Default,
+{
+    println!("info(database): {}", diesel::debug_query::<U, _>(query));
+}
+
+/// Determine the appropriate status code for a database error kind.
+fn status_for_database_error(kind: &DatabaseErrorKind) -> StatusCode {
+    match kind {
+        // A required column value is not present in the operation arguments.
+        DatabaseErrorKind::NotNullViolation => StatusCode::BAD_REQUEST,
+
+        // The operation conflicts with the current state of the system.
+        DatabaseErrorKind::ExclusionViolation
+        | DatabaseErrorKind::ForeignKeyViolation
+        | DatabaseErrorKind::RestrictViolation
+        | DatabaseErrorKind::SerializationFailure
+        | DatabaseErrorKind::UniqueViolation => StatusCode::CONFLICT,
+
+        // The result of the operation would violate semantic rules.
+        DatabaseErrorKind::CheckViolation => StatusCode::UNPROCESSABLE_ENTITY,
+
+        // The database is temporarily unavailable.
+        DatabaseErrorKind::ClosedConnection => StatusCode::SERVICE_UNAVAILABLE,
+
+        // All other errors are opaque.
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+impl<T, U> AsyncQueryDsl<T> for U where U: RunQueryDsl<T> {}
+
+impl<F, T> Future for MapErr<F>
+where
+    F: Future<Output = QueryResult<T>> + Unpin,
+{
+    type Output = via::Result<T>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
+        match Pin::new(&mut self.future).poll(context) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(data)) => Poll::Ready(Ok(data)),
+            Poll::Ready(Err(error)) => {
+                #[cfg(debug_assertions)]
+                eprintln!("error(database): {}", &error);
+
+                // Placeholder for tracing...
+
+                match &error {
+                    // No rows were returned by a query expected to return at least one row.
+                    DieselError::NotFound => Poll::Ready(Err(err!(404, "not found"))),
+
+                    // An error was returned by the database.
+                    DieselError::DatabaseError(kind, info) => {
+                        let status = status_for_database_error(kind);
+                        let message = info.message();
+
+                        Poll::Ready(Err(err!(status, "{}", message)))
+                    }
+
+                    // The error occured for some other reason.
+                    _ => Poll::Ready(Err(err!(500, "internal server error"))),
+                }
+            }
+        }
+    }
+}

--- a/via-diesel/src/query_dsl.rs
+++ b/via-diesel/src/query_dsl.rs
@@ -133,7 +133,7 @@ where
             Poll::Ready(Ok(data)) => Poll::Ready(Ok(data)),
             Poll::Ready(Err(error)) => {
                 #[cfg(debug_assertions)]
-                eprintln!("error(database): {}", &error);
+                eprintln!("error(database): {}", error);
 
                 // Placeholder for tracing...
 


### PR DESCRIPTION
Moves via-diesel into the workspace to keep pre-release crates in lockstep with one and other. It can move to a separate repository when the official 2.0 release is published.