### PR TITLE
feat(via): Error::from_serde_json prevents double box

### DIFF
--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -120,6 +120,13 @@ impl Error {
         Self::from_source_with_status(status, Box::new(error))
     }
 
+    pub fn from_serde_json(status: StatusCode, error: serde_json::Error) -> Self {
+        Self {
+            status,
+            source: ErrorSource::Json(error),
+        }
+    }
+
     /// Returns an `Error` from a boxed [`Error` trait](std::error::Error)
     /// object.
     pub fn from_source(source: BoxError) -> Self {
@@ -184,20 +191,6 @@ impl Error {
         let mut error = Self::new(format!("missing required query parameter: \"{}\".", name));
         error.status = StatusCode::BAD_REQUEST;
         error
-    }
-
-    pub(crate) fn ser_json(source: serde_json::Error) -> Self {
-        Self {
-            status: StatusCode::INTERNAL_SERVER_ERROR,
-            source: ErrorSource::Json(source),
-        }
-    }
-
-    pub(crate) fn de_json(source: serde_json::Error) -> Self {
-        Self {
-            status: StatusCode::BAD_REQUEST,
-            source: ErrorSource::Json(source),
-        }
     }
 
     #[inline]

--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, Bytes};
-use http::HeaderMap;
+use http::{HeaderMap, StatusCode};
 use http_body::{Body, Frame, SizeHint};
 use hyper::body::Incoming;
 use serde::Deserialize;
@@ -259,7 +259,8 @@ fn deserialize_json<T>(buf: &[u8]) -> Result<T, Error>
 where
     T: DeserializeOwned,
 {
-    serde_json::from_slice(buf).map_err(Error::de_json)
+    serde_json::from_slice(buf)
+        .map_err(|error| Error::from_serde_json(StatusCode::BAD_REQUEST, error))
 }
 
 #[inline]

--- a/via/src/response/builder.rs
+++ b/via/src/response/builder.rs
@@ -98,11 +98,17 @@ impl ResponseBuilder {
 
     #[inline]
     pub fn json(self, body: &impl Serialize) -> Result<Response, Error> {
-        let body = serde_json::to_vec(body).map_err(Error::ser_json)?;
+        match serde_json::to_vec(body) {
+            Ok(body) => self
+                .header(CONTENT_LENGTH, body.len())
+                .header(CONTENT_TYPE, "application/json; charset=utf-8")
+                .body(ResponseBody::from(body)),
 
-        self.header(CONTENT_LENGTH, body.len())
-            .header(CONTENT_TYPE, "application/json; charset=utf-8")
-            .body(ResponseBody::from(body))
+            Err(error) => Err(Error::from_serde_json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error,
+            )),
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Provides a way for users to wrap `serde_json` errors without having to box an error type that is already boxed. 