### PR TITLE
fix(via): Payload::timeout_after_secs -> impl Future + Send

### DIFF
--- a/via/src/request/payload.rs
+++ b/via/src/request/payload.rs
@@ -486,7 +486,7 @@ macro_rules! impl_timeout_after {
             pub fn timeout_after_secs(
                 self,
                 seconds: u64,
-            ) -> impl Future<Output = Result<Aggregate, Error>> {
+            ) -> impl Future<Output = Result<Aggregate, Error>> + Send {
                 self.timeout_after(Duration::from_secs(seconds))
             }
         }


### PR DESCRIPTION
Adds `Send` to the bounds on the Future returned by `::timeout_after_secs`.