### PR TITLE
fix(via-diesel): default PER_PAGE is not MIN_PER_PAGE

### DIFF
--- a/via-diesel/src/lib.rs
+++ b/via-diesel/src/lib.rs
@@ -1,5 +1,6 @@
+pub mod paginate;
+
 mod macros;
-mod paginate;
 mod query_dsl;
 
 pub use paginate::{LimitAndOffset, LimitAndPage, Paginate};

--- a/via-diesel/src/paginate.rs
+++ b/via-diesel/src/paginate.rs
@@ -6,6 +6,9 @@ use via::{Error, ResultExt};
 const MIN_PER_PAGE: i64 = 5;
 const MAX_PER_PAGE: i64 = 100;
 
+/// The default number of rows returned by a paginated query.
+pub const PER_PAGE: i64 = 25;
+
 pub trait Paginate<T> {
     type Output;
     fn page(self, cursor: T) -> Self::Output;
@@ -61,12 +64,18 @@ impl TryFrom<QueryParams<'_>> for LimitAndOffset {
     type Error = via::Error;
 
     fn try_from(query: QueryParams<'_>) -> via::Result<Self> {
-        let limit = map_or(query.first("limit"), MIN_PER_PAGE, str::parse)?;
-        let offset = map_or(query.first("offset"), 0, str::parse)?;
-
         Ok(Self {
-            limit: limit.clamp(MIN_PER_PAGE, MAX_PER_PAGE),
-            offset: offset.max(0),
+            limit: query
+                .first("limit")
+                .ok_and_then(str::parse)?
+                .unwrap_or(PER_PAGE)
+                .clamp(MIN_PER_PAGE, MAX_PER_PAGE),
+
+            offset: query
+                .first("offset")
+                .ok_and_then::<_, i64, _>(str::parse)?
+                .unwrap_or_default()
+                .max(0),
         })
     }
 }
@@ -75,17 +84,21 @@ impl TryFrom<QueryParams<'_>> for LimitAndPage {
     type Error = via::Error;
 
     fn try_from(query: QueryParams<'_>) -> via::Result<Self> {
-        let page = map_or(query.first("page"), 1i64, str::parse)?;
+        let page = query.first("page").ok_and_then(str::parse)?.unwrap_or(1i64);
+        let limit = query
+            .first("limit")
+            .ok_and_then(str::parse)?
+            .unwrap_or(MIN_PER_PAGE);
 
         if page < 1 {
             via::deny!(400, "page must be a positive integer");
         }
 
-        let limit = map_or(query.first("limit"), MIN_PER_PAGE, str::parse)?;
-        let offset = (page - 1).saturating_mul(limit);
-
         Ok(Self {
-            limit_and_offset: LimitAndOffset { limit, offset },
+            limit_and_offset: LimitAndOffset {
+                offset: (page - 1).saturating_mul(limit),
+                limit,
+            },
         })
     }
 }

--- a/via-diesel/src/paginate.rs
+++ b/via-diesel/src/paginate.rs
@@ -1,7 +1,6 @@
-use diesel::dsl::Offset;
+use diesel::helper_types::Offset;
 use diesel::query_dsl::methods::{LimitDsl, OffsetDsl};
-use via::request::params::{QueryParam, QueryParams};
-use via::{Error, ResultExt};
+use via::request::params::QueryParams;
 
 const MIN_PER_PAGE: i64 = 5;
 const MAX_PER_PAGE: i64 = 100;
@@ -23,17 +22,6 @@ pub struct LimitAndOffset {
 #[derive(Debug)]
 pub struct LimitAndPage {
     limit_and_offset: LimitAndOffset,
-}
-
-fn map_or<F, T, E>(param: QueryParam, default: T, op: F) -> Result<T, Error>
-where
-    F: FnOnce(&str) -> Result<T, E>,
-    Error: From<E>,
-{
-    param.ok().and_then(|option| match option.as_deref() {
-        Some(value) => op(value).or_bad_request(),
-        None => Ok(default),
-    })
 }
 
 impl<T> Paginate<LimitAndOffset> for T

--- a/via-diesel/src/paginate.rs
+++ b/via-diesel/src/paginate.rs
@@ -88,7 +88,8 @@ impl TryFrom<QueryParams<'_>> for LimitAndPage {
         let limit = query
             .first("limit")
             .ok_and_then(str::parse)?
-            .unwrap_or(MIN_PER_PAGE);
+            .unwrap_or(PER_PAGE)
+            .clamp(MIN_PER_PAGE, MAX_PER_PAGE);
 
         if page < 1 {
             via::deny!(400, "page must be a positive integer");


### PR DESCRIPTION
Fixes a bug in via-diesel where the default number of rows returned per page was also the minimum. Also removes the `map_or` helper in favor the `ok_and_then` combinator introduced by #624.