### PR TITLE
refactor(via): newtype mut ws stream

### DIFF
--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -90,7 +90,10 @@ where
 //
 // We know that this borrow is always valid because `Facade` only ever exists
 // as a field of `Run` and `Run` never mutates the `stream` field. Therefore,
-// the `*mut WebSocketStream` always points to a valid `WebSocketStream`.
+// the `*mut WebSocketStream` always points to a valid `WebSocketStream`. Both
+// `Facade` and `Run` have manual drop impls to provide a deterministic drop
+// order where the raw pointer contained in `Facade` is nulled before the rest
+// of the fields of `Run` are dropped.
 //
 // There is no reason to provide `Facade` with a phantom lifetime to represent
 // the validity of the `stream` in this context becuase it's lifetime is that of

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -229,8 +229,8 @@ impl Future for Facade {
                     log!(info(ws = i), "state = send");
                     indent!(i);
 
-                    match self.stream.as_pin_mut().poll_ready(cx).map_err(rescue)? {
-                        Poll::Ready(_) => {
+                    match self.stream.as_pin_mut().poll_ready(cx) {
+                        Poll::Ready(Ok(_)) => {
                             self.stream.as_pin_mut().start_send(item).map_err(rescue)?;
                             log!(info(ws = i), "outbound message accepted by i/o.");
                             indent!(i);
@@ -239,6 +239,9 @@ impl Future for Facade {
                             log!(info(ws = i), "waiting for i/o to become available.");
                             self.state = IoState::Send(item);
                             return Poll::Pending;
+                        }
+                        Poll::Ready(Err(error)) => {
+                            return Poll::Ready(Err(rescue(error)));
                         }
                     }
                 }

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -33,7 +33,7 @@ enum IoState {
 struct Facade {
     listener: Pin<Box<dyn Future<Output = super::Result> + Send>>,
     state: IoState,
-    stream: *mut WebSocketStream<IoStream>,
+    stream: WebSocketStreamMut,
     rendezvous: Channel,
 }
 
@@ -43,6 +43,10 @@ struct Run<T, App> {
     stream: WebSocketStream<IoStream>,
     facade: Option<Facade>,
     _pin: PhantomPinned,
+}
+
+struct WebSocketStreamMut {
+    io: *mut WebSocketStream<IoStream>,
 }
 
 impl<T, App, Await> RunTask<T, App>
@@ -79,6 +83,41 @@ where
     }
 }
 
+impl<T, App> Drop for Run<T, App> {
+    fn drop(&mut self) {
+        if let Some(facade) = self.facade.take() {
+            // Safety: Explicitly dropping facade, invalidates the raw pointer.
+            drop(facade);
+        }
+    }
+}
+
+impl Drop for Facade {
+    fn drop(&mut self) {
+        // Null out the raw pointer to prevent accidental use.
+        // The rest of the fields in self are dropped automatically.
+        self.stream.io = std::ptr::null_mut();
+    }
+}
+
+impl WebSocketStreamMut {
+    #[inline]
+    fn new(io: &mut WebSocketStream<IoStream>) -> Self {
+        Self { io }
+    }
+
+    #[inline(always)]
+    fn as_pin_mut(&mut self) -> Pin<&mut WebSocketStream<IoStream>> {
+        // Safety:
+        //
+        // The raw pointer at `self.io` is always valid because `Run` never moves
+        // or reassigns the value stored in the `stream` field and `Facade` and
+        // `Run` implement drop to explicitly null the `*mut WebSocketStream`
+        // prior to dropping the value that it points to.
+        Pin::new(unsafe { &mut *self.io })
+    }
+}
+
 // Safety:
 //
 // In order for `Run` to act as a supervisor of `Facade`, `Run` must construct
@@ -86,41 +125,22 @@ where
 // `facade` field of `Run` self-referential.
 //
 // To properly facilitate this behavior, `Run` constructs the `facade` field
-// with a `*mut WebSocketStream`.
+// with a `*mut WebSocketStream` in `WebSocketStreamMut`. We know that this
+// borrow is always valid because:
 //
-// We know that this borrow is always valid because `Facade` only ever exists
-// as a field of `Run` and `Run` never mutates the `stream` field. Therefore,
-// the `*mut WebSocketStream` always points to a valid `WebSocketStream`. Both
-// `Facade` and `Run` have manual drop impls to provide a deterministic drop
-// order where the raw pointer contained in `Facade` is nulled before the rest
-// of the fields of `Run` are dropped.
+// - `Facade` can only exist as a field of `Run`
 //
-// There is no reason to provide `Facade` with a phantom lifetime to represent
-// the validity of the `stream` in this context becuase it's lifetime is that of
-// self and the lifetime of self is the lifetime `Run`.
+// - `Run` can only be constructed with a stable heap address as `Pin<Box<Run>>`
 //
-// `Run` is only ever constructed as a field of `RunTask` a context in which it
-// is `Pin<Box<Run>>`. Since `facade` is a field of `Run` and `Run` is guaranteed
-// a stable memory address because it can only exist as `Pin<Box<Run>>`, we can
-// be sure that no aliasing rules are being broken.
+// - `Run` never moves or reassigns the value stored in the `stream` field
 //
-// Now that we can be sure that the `*mut WebSocketStream` in `facade` is both
-// justified and well-behaved, the only other qualifier required to safely
-// implement `Send` is `WebSocketStream` being `Send` along with the other
-// fields of `facade`.
+// - `Facade` explicitly nulls the `stream` field in it's drop impl and `Run`
+//   explicitly drops `facade` before `stream`
 //
-// This impl `Send` remains safe so long as `Run` only exists as `Pin<Box<Run>>`
-// and uncommenting the `impl Send` only mentions the `stream` field in the
-// diagnostic message.
-unsafe impl Send for Facade {}
-
-impl Drop for Facade {
-    fn drop(&mut self) {
-        // Null out the raw pointer to prevent accidental use.
-        // The rest of the fields in self are dropped automatically.
-        self.stream = std::ptr::null_mut();
-    }
-}
+// There is no reason to provide `WebSocketStreamMut` with a phantom lifetime to
+// represent the validity of the `io` becuase it's lifetime is that of self and
+// the lifetime of self is the lifetime `Run`.
+unsafe impl Send for WebSocketStreamMut {}
 
 macro_rules! indent {
     ($i:ident = $value:expr) => {
@@ -142,14 +162,6 @@ impl Future for Facade {
         let mut i = 0;
 
         loop {
-            // Safety:
-            //
-            // stream is a mutable pointer to the stream field of the `Run<_, _>`
-            // struct. Run is structurally pinned in a `Pin<Box<_>>` as a field
-            // of `RunTask`. The only way to construct `Run<_, _>` is with the
-            // `RunTask::new` fn.
-            let stream = unsafe { &mut *self.stream };
-
             match &mut self.state {
                 IoState::Receive => {
                     log!(info(ws = i), "state = receive");
@@ -158,15 +170,21 @@ impl Future for Facade {
                     // Confirm that the listener can receive the next message.
                     if self.rendezvous.has_capacity()? {
                         // Attempt to pull the next message out of the stream.
-                        if let Poll::Ready(next) = Pin::new(stream).poll_next(cx).map_err(rescue)? {
-                            let Some(received) = next else {
-                                // The stream has ended. The web socket is closed.
+                        match self.stream.as_pin_mut().poll_next(cx) {
+                            Poll::Ready(Some(Ok(next))) => {
+                                // If send fails, the channel is disconnected.
+                                self.rendezvous.try_send(next)?;
+                                log!(info(ws = i), "inbound message forwarded to listener.");
+                            }
+                            Poll::Ready(Some(Err(error))) => {
+                                return Poll::Ready(Err(rescue(error)));
+                            }
+                            // The stream has ended. The web socket is closed.
+                            Poll::Ready(None) => {
                                 return Poll::Ready(Ok(()));
-                            };
-
-                            // If send fails, the channel is disconnected.
-                            self.rendezvous.try_send(received)?;
-                            log!(info(ws = i), "inbound message forwarded to listener.");
+                            }
+                            // The stream is empty. Poll the listener.
+                            Poll::Pending => {}
                         }
                     } else {
                         log!(info(ws = i), "listener is busy.");
@@ -179,10 +197,9 @@ impl Future for Facade {
                     }
 
                     if let Some(sent) = self.rendezvous.try_recv()? {
+                        self.state = IoState::Send(sent);
                         log!(info(ws = i), "outbound message received from listener.");
                         indent!(i);
-
-                        self.state = IoState::Send(sent);
                     } else {
                         log!(info(ws = i), "waiting for something interesting to happen.");
                         return Poll::Pending;
@@ -190,25 +207,25 @@ impl Future for Facade {
                 }
 
                 state @ IoState::Send(_) => {
+                    let IoState::Send(item) = mem::replace(state, IoState::Flush) else {
+                        // We are in an invalid state. End the session.
+                        return Poll::Ready(Ok(()));
+                    };
+
                     log!(info(ws = i), "state = send");
                     indent!(i);
 
-                    let mut sink = Pin::new(stream);
-
-                    if sink.as_mut().poll_ready(cx).map_err(rescue)?.is_pending() {
-                        log!(info(ws = i), "waiting for i/o to become available.");
-                        return Poll::Pending;
-                    }
-
-                    if let IoState::Send(message) = mem::replace(state, IoState::Flush) {
-                        sink.as_mut().start_send(message).map_err(rescue)?;
-                        log!(info(ws = i), "outbound message accepted by i/o.");
-                        indent!(i);
-                    } else {
-                        // We are in an invalid state. This can be interpreted
-                        // as a signal that the risk of re-entrance is elevated
-                        // and we should close the socket.
-                        return Poll::Ready(Ok(()));
+                    match self.stream.as_pin_mut().poll_ready(cx).map_err(rescue)? {
+                        Poll::Ready(_) => {
+                            self.stream.as_pin_mut().start_send(item).map_err(rescue)?;
+                            log!(info(ws = i), "outbound message accepted by i/o.");
+                            indent!(i);
+                        }
+                        Poll::Pending => {
+                            log!(info(ws = i), "waiting for i/o to become available.");
+                            self.state = IoState::Send(item);
+                            return Poll::Pending;
+                        }
                     }
                 }
 
@@ -216,12 +233,18 @@ impl Future for Facade {
                     log!(info(ws = i), "state = flush");
                     indent!(i);
 
-                    if Pin::new(stream).poll_flush(cx).map_err(rescue)?.is_ready() {
-                        log!(info(ws = i), "outbound message sent successfully.");
-                        self.state = IoState::Receive;
-                        cx.waker().wake_by_ref();
-                    } else {
-                        log!(info(ws = i), "waiting for flush to complete.");
+                    match self.stream.as_pin_mut().poll_flush(cx) {
+                        Poll::Pending => {
+                            log!(info(ws = i), "waiting for flush to complete.");
+                        }
+                        Poll::Ready(Ok(_)) => {
+                            log!(info(ws = i), "outbound message sent successfully.");
+                            self.state = IoState::Receive;
+                            cx.waker().wake_by_ref();
+                        }
+                        Poll::Ready(Err(error)) => {
+                            return Poll::Ready(Err(rescue(error)));
+                        }
                     }
 
                     return Poll::Pending;
@@ -243,7 +266,7 @@ where
         let facade = Facade {
             listener: Box::pin((self.listener.handle)(theirs, request)),
             state: IoState::Receive,
-            stream: &mut self.stream as *mut _,
+            stream: WebSocketStreamMut::new(&mut self.stream),
             rendezvous: ours,
         };
 
@@ -256,15 +279,6 @@ where
         // Implementing this any other way introduces an unlikely yet
         // recognizable re-entrancy pattern.
         unsafe { self.facade.as_mut().unwrap_unchecked() }
-    }
-}
-
-impl<T, App> Drop for Run<T, App> {
-    fn drop(&mut self) {
-        if let Some(facade) = self.facade.take() {
-            // Safety: Explicitly dropping facade, invalidates the raw pointer.
-            drop(facade);
-        }
     }
 }
 

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -79,6 +79,36 @@ where
     }
 }
 
+// Safety:
+//
+// In order for `Run` to act as a supervisor of `Facade`, `Run` must construct
+// `Facade` with a mutable reference to it's `stream` field. This makes the
+// `facade` field of `Run` self-referential.
+//
+// To properly facilitate this behavior, `Run` constructs the `facade` field
+// with a `*mut WebSocketStream`.
+//
+// We know that this borrow is always valid because `Facade` only ever exists
+// as a field of `Run` and `Run` never mutates the `stream` field. Therefore,
+// the `*mut WebSocketStream` always points to a valid `WebSocketStream`.
+//
+// There is no reason to provide `Facade` with a phantom lifetime to represent
+// the validity of the `stream` in this context becuase it's lifetime is that of
+// self and the lifetime of self is the lifetime `Run`.
+//
+// `Run` is only ever constructed as a field of `RunTask` a context in which it
+// is `Pin<Box<Run>>`. Since `facade` is a field of `Run` and `Run` is guaranteed
+// a stable memory address because it can only exist as `Pin<Box<Run>>`, we can
+// be sure that no aliasing rules are being broken.
+//
+// Now that we can be sure that the `*mut WebSocketStream` in `facade` is both
+// justified and well-behaved, the only other qualifier required to safely
+// implement `Send` is `WebSocketStream` being `Send` along with the other
+// fields of `facade`.
+//
+// This impl `Send` remains safe so long as `Run` only exists as `Pin<Box<Run>>`
+// and uncommenting the `impl Send` only mentions the `stream` field in the
+// diagnostic message.
 unsafe impl Send for Facade {}
 
 impl Drop for Facade {

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -118,10 +118,11 @@ impl WebSocketStreamMut {
     fn as_pin_mut(&mut self) -> Pin<&mut WebSocketStream<IoStream>> {
         // Safety:
         //
-        // The raw pointer at `self.io` is always valid because `Run` never moves
-        // or reassigns the value stored in the `stream` field and `Facade` and
-        // `Run` implement drop to explicitly null the `*mut WebSocketStream`
-        // prior to dropping the value that it points to.
+        // The raw pointer at `self.io` is always valid because:
+        //
+        // - `Run` never moves or reassigns the value stored at `stream`
+        // - `Self` only occurs as a field of `Facade`, `Facade` can only occur
+        //   as a field of `Run` and `Run` can only occur as `Pin<Box<Run>>`
         Pin::new(unsafe { &mut *self.io })
     }
 }

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -94,8 +94,16 @@ impl<T, App> Drop for Run<T, App> {
 
 impl Drop for Facade {
     fn drop(&mut self) {
-        // Null out the raw pointer to prevent accidental use.
-        // The rest of the fields in self are dropped automatically.
+        // Defensive poisoning. Dereferencing a null ptr and a dangling reference
+        // to an I/O stream are both undefined behavior. However, dereferencing a
+        // null ptr is inherently less risky on modern operating systems.
+        //
+        // Accessing a value after it has been dropped is impossible to do in
+        // Safe Rust and none of the unsafe blocks found in this module allow
+        // it to happen.
+        //
+        // Soundness relies on `Facade` being dropped before the `Run::stream`
+        // field is dropped in `impl Drop for Run`.
         self.stream.io = std::ptr::null_mut();
     }
 }
@@ -117,6 +125,11 @@ impl WebSocketStreamMut {
         Pin::new(unsafe { &mut *self.io })
     }
 }
+
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<WebSocketStream<IoStream>>();
+};
 
 // Safety:
 //


### PR DESCRIPTION
Tightens the claims in #630 by further integrating them into the type system.

Also makes the reborrowing of `Pin<&mut WebSocketStream>` more likely to be transformed into simple method calls to a mutable receiver.