### PR TITLE
feat(via-pubsub): bounded pipeline size

### DIFF
--- a/examples/chat/src/app.rs
+++ b/examples/chat/src/app.rs
@@ -34,6 +34,9 @@ const PUBSUB_VERSION: u32 = 1;
 /// The signing key used to sign and verify session cookies.
 const SESSION_SIGNER: &str = "SESSION_SIGNER";
 
+/// The maximum size in bytes of chat message or reaction.
+pub const MAX_EVENT_SIZE: usize = 8192;
+
 /// The cookie name used to store an encoded identity token.
 pub const SESSION: &str = "via-chat-session";
 
@@ -209,6 +212,7 @@ impl Unicorn {
 
             Redis::builder(PUBSUB_SCOPE)
                 .concurrency(num_workers)
+                .max_event_size(MAX_EVENT_SIZE)
                 .signing_key(require_secret(PUBSUB_SIGNER)?.as_bytes())
                 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 //     Signing key is dropped and zeroed before await.

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -30,6 +30,9 @@ use routes::auth::{login, logout, me};
 use routes::{channels, reactions, threads, users};
 use util::session::{self, auth_required, authenticate};
 
+#[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
+use crate::app::MAX_EVENT_SIZE;
+
 type Request = via::Request<Unicorn>;
 type Next = via::Next<Unicorn>;
 
@@ -89,7 +92,12 @@ fn routes(home: via::Route<Unicorn>) {
 
     // The /api/chat route.
     #[cfg(any(feature = "tokio-tungstenite", feature = "tokio-websockets"))]
-    path.route("/chat", via::get(authenticate(via::ws(routes::chat))));
+    path.route(
+        "/chat",
+        via::get(authenticate(
+            via::ws(routes::chat).max_message_size(Some(MAX_EVENT_SIZE)),
+        )),
+    );
 
     // The /api/channels resource.
     path.route("/channels", channels::collection(auth_required))

--- a/via-pubsub/src/backend/redis.rs
+++ b/via-pubsub/src/backend/redis.rs
@@ -12,8 +12,12 @@ use super::{Backend, Event, RawPeerEvent};
 use crate::pubsub::Pubsub;
 use crate::util::error;
 
+/// The maximum size in bytes of a pipeline command.
+const MAX_PIPELINE_SIZE: usize = 65536;
+
 pub struct Builder<'a, T, U> {
     concurrency: Option<usize>,
+    max_event_size: Option<usize>,
     signing_key: Result<Option<Key>, Error>,
     sub_scope: &'a str,
     version: Option<u32>,
@@ -167,6 +171,7 @@ impl<T, U> Redis<T, U> {
     pub fn builder(scope: &str) -> Builder<'_, T, U> {
         Builder {
             concurrency: None,
+            max_event_size: None,
             signing_key: Ok(None),
             sub_scope: scope,
             version: None,
@@ -236,6 +241,14 @@ where
             .concurrency
             .ok_or_else(|| require_argument("concurrency"))?;
 
+        // Confirm that `max_event_size` was provided.
+        //
+        // We use this to determine the maximum number of events that can be
+        // safely included in a pipeline command to redis.
+        let max_event_size = self
+            .max_event_size
+            .ok_or_else(|| require_argument("max_event_size"))?;
+
         // Used by subscribers to send updates to the redis task.
         let (sender, outbound) = mpsc::channel(concurrency);
 
@@ -291,7 +304,7 @@ where
                 fanout,
                 inbound,
                 outbound,
-                concurrency,
+                concurrency: MAX_PIPELINE_SIZE.div_euclid(max_event_size),
             };
 
             // Pin the task on the heap. It should live as long as the process.
@@ -331,6 +344,19 @@ where
     /// ```
     pub fn concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = Some(concurrency);
+        self
+    }
+
+    /// The maximum size event size in bytes of a serialized event.
+    ///
+    /// The provided value is treated as an upper bound to determine a
+    /// pathological publish burst.
+    ///
+    /// This allows us to calculate the number of events that can be safely
+    /// included in a pipeline request to redis without keeping a running total
+    /// of the size in bytes of the command.
+    pub fn max_event_size(mut self, max: usize) -> Self {
+        self.max_event_size = Some(max);
         self
     }
 


### PR DESCRIPTION
Creates an upper bound on the number of commands that can be included in a redis pipeline by dividing a global maximum 64kb by a configurable max_event_size. This allow us to determine the pathological worst case without keeping a running total. We are high assurance. We assume worst case.