### PR TITLE
chore(via): v2.0.0-gm.61 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "=2.0.0-gm.60"
+via = "=2.0.0-gm.61"
 http = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -78,7 +78,7 @@ serde_json = "1"
 time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1", features = ["v4", "serde"] }
-via = { path = "../via", version = "=2.0.0-gm.60" }
-via-diesel = { path = "../via-diesel", version = "=0.1.0-beta.2" }
-via-pubsub = { path = "../via-pubsub", version = "0.1.0-beta.0", features = ["redis"] }
+via = { path = "../via", version = "=2.0.0-gm.61" }
+via-diesel = { path = "../via-diesel", version = "=0.1.0-beta.3" }
+via-pubsub = { path = "../via-pubsub", version = "0.1.0-beta.1", features = ["redis"] }
 zeroize = { version = "1", features = ["serde"] }

--- a/via-diesel/Cargo.toml
+++ b/via-diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-diesel"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -12,4 +12,4 @@ repository = "https://github.com/via-rs/via"
 diesel-async = "0.9"
 diesel = "2"
 http = "1"
-via = { path = "../via", version = "=2.0.0-gm.60" }
+via = { version = "=2.0.0-gm.61", path = "../via" }

--- a/via-pubsub/Cargo.toml
+++ b/via-pubsub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-pubsub"
-version = "0.1.0-beta.0"
+version = "0.1.0-beta.1"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ serde = { version = "1" }
 serde_json = "1"
 sha2 = "0.11"
 tokio = "1"
-via = { version = "=2.0.0-gm.60", path = "../via" }
+via = { version = "=2.0.0-gm.61", path = "../via" }
 zeroize = "1"
 
 [dependencies.redis]

--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-gm.60"
+version = "2.0.0-gm.61"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Updates the version of the following crates in preparation for release:

- `via = "=2.0.0-gm.61"`
- `via-diesel = "=0.1.0-beta.3"`
- `via-pubsub = "=0.1.0-beta.1"`

---

## Changelog

- #632
- #631