### PR TITLE
feat(via): lag is an event not an error

### DIFF
--- a/examples/chat/src/routes/chat.rs
+++ b/examples/chat/src/routes/chat.rs
@@ -190,11 +190,11 @@ fn deserialize_client_event(message: &Message) -> via::Result<ClientEvent> {
 fn serialize_lag_notification(length: u64) -> ws::Result<String> {
     #[derive(Serialize)]
     #[serde(content = "data", rename_all = "lowercase", tag = "type")]
-    enum LagNotifiction {
+    enum LagNotification {
         Lag { length: u64 },
     }
 
-    serde_json::to_string(&LagNotifiction::Lag { length }).or_continue()
+    serde_json::to_string(&LagNotification::Lag { length }).or_continue()
 }
 
 #[cfg(all(debug_assertions, feature = "tokio-tungstenite"))]

--- a/examples/chat/src/routes/chat.rs
+++ b/examples/chat/src/routes/chat.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::task::coop;
 use via::deny;
 use via::error::{Catch, Propagate};
@@ -139,6 +139,13 @@ pub async fn chat(mut channel: Channel, request: Request) -> ws::Result {
 
         if let Some(event) = inbound {
             match event {
+                // Lag detected in `subscription`.
+                PeerEvent::Lag(len) => {
+                    log!(info(chat = 1), "lag notification; len = {}", len);
+                    channel.send(serialize_lag_notification(len)?).await?;
+                    return ws::restart().await;
+                }
+
                 // The user logged out.
                 PeerEvent::Logout => {
                     log!(info(chat = 1), "ws session ended");
@@ -147,8 +154,7 @@ pub async fn chat(mut channel: Channel, request: Request) -> ws::Result {
 
                 // Notification received from a peer.
                 PeerEvent::Relay(notification) => {
-                    log!(info(chat = 1), "relay notification");
-                    channel.send(notification).await?
+                    channel.send(notification).await?;
                 }
 
                 // The user was invited to a channel.
@@ -179,6 +185,16 @@ fn deserialize_client_event(message: &Message) -> via::Result<ClientEvent> {
     let text = str::from_utf8(payload)?;
 
     Ok(serde_json::from_str(text)?)
+}
+
+fn serialize_lag_notification(length: u64) -> ws::Result<String> {
+    #[derive(Serialize)]
+    #[serde(content = "data", rename_all = "lowercase", tag = "type")]
+    enum LagNotifiction {
+        Lag { length: u64 },
+    }
+
+    serde_json::to_string(&LagNotifiction::Lag { length }).or_continue()
 }
 
 #[cfg(all(debug_assertions, feature = "tokio-tungstenite"))]

--- a/via-pubsub/src/backend/mod.rs
+++ b/via-pubsub/src/backend/mod.rs
@@ -36,6 +36,7 @@ pub trait Backend {
 
 #[derive(Clone, Debug)]
 pub enum PeerEvent<T> {
+    Lag(u64),
     Logout,
     Relay(Opaque),
     Register(T),
@@ -44,6 +45,7 @@ pub enum PeerEvent<T> {
 
 #[derive(Clone)]
 pub enum RawPeerEvent<T> {
+    Lag(u64),
     Logout(T),
     Relay(T, Opaque),
     Register(Option<T>, T),

--- a/via-pubsub/src/backend/redis.rs
+++ b/via-pubsub/src/backend/redis.rs
@@ -206,12 +206,11 @@ where
     }
 
     async fn recv(&mut self) -> Result<RawPeerEvent<T>, Catch> {
-        self.receiver.recv().await.map_err(|error| {
-            if let broadcast::error::RecvError::Lagged(n) = error {
-                let message = format!("capacity too small. skipped {} messages.", n);
-                ControlFlow::Continue(Error::new(message))
+        self.receiver.recv().await.or_else(|error| {
+            if let broadcast::error::RecvError::Lagged(len) = error {
+                Ok(RawPeerEvent::Lag(len))
             } else {
-                error::sender_dropped(0)
+                Err(error::sender_dropped(0))
             }
         })
     }

--- a/via-pubsub/src/pubsub.rs
+++ b/via-pubsub/src/pubsub.rs
@@ -62,6 +62,8 @@ impl<T: Backend> Subscription<T> {
     #[inline]
     fn interested_in(&self, event: RawPeerEvent<T::Interest>) -> Option<PeerEvent<T::Interest>> {
         match event {
+            RawPeerEvent::Lag(len) => Some(PeerEvent::Lag(len)),
+
             RawPeerEvent::Logout(actor) => (actor == self.actor).then_some(PeerEvent::Logout),
 
             RawPeerEvent::Relay(interest, payload) => self

--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -44,6 +44,8 @@ enum ErrorSource {
     Message(String),
     Other(BoxError),
     Json(serde_json::Error),
+
+    #[allow(dead_code)]
     Restart,
 }
 
@@ -195,6 +197,7 @@ impl Error {
         error
     }
 
+    #[allow(dead_code)]
     pub(crate) fn restart() -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -202,6 +205,7 @@ impl Error {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_restart(&self) -> bool {
         matches!(&self.source, ErrorSource::Restart)
     }

--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -44,6 +44,7 @@ enum ErrorSource {
     Message(String),
     Other(BoxError),
     Json(serde_json::Error),
+    Restart,
 }
 
 enum ErrorSourceRef<'a> {
@@ -51,6 +52,7 @@ enum ErrorSourceRef<'a> {
     Message(&'a str),
     Other(&'a (dyn std::error::Error + 'static)),
     Json(&'a serde_json::Error),
+    Restart,
 }
 
 #[derive(Serialize)]
@@ -193,6 +195,17 @@ impl Error {
         error
     }
 
+    pub(crate) fn restart() -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            source: ErrorSource::Restart,
+        }
+    }
+
+    pub(crate) fn is_restart(&self) -> bool {
+        matches!(&self.source, ErrorSource::Restart)
+    }
+
     #[inline]
     fn as_source(&self) -> ErrorSourceRef<'_> {
         match &self.source {
@@ -200,6 +213,7 @@ impl Error {
             ErrorSource::Message(message) => ErrorSourceRef::Message(message),
             ErrorSource::Other(source) => ErrorSourceRef::Other(source.as_ref()),
             ErrorSource::Json(source) => ErrorSourceRef::Json(source),
+            ErrorSource::Restart => ErrorSourceRef::Restart,
         }
     }
 
@@ -209,6 +223,7 @@ impl Error {
             ErrorSource::AllowMethod(error) => Err(Some(error)),
             ErrorSource::Other(error) => Err(Some(&**error)),
             ErrorSource::Json(error) => Err(Some(error)),
+            ErrorSource::Restart => Err(None),
         }
     }
 
@@ -240,6 +255,7 @@ impl Display for Error {
             ErrorSourceRef::AllowMethod(source) => Display::fmt(source, f),
             ErrorSourceRef::Other(source) => Display::fmt(source, f),
             ErrorSourceRef::Json(source) => Display::fmt(source, f),
+            ErrorSourceRef::Restart => write!(f, "restart"),
         }
     }
 }
@@ -251,6 +267,7 @@ impl From<Error> for BoxError {
             ErrorSource::Message(string) => string.into(),
             ErrorSource::Other(source) => source,
             ErrorSource::Json(source) => source.into(),
+            ErrorSource::Restart => "restart".to_owned().into(),
         }
     }
 }

--- a/via/src/error/mod.rs
+++ b/via/src/error/mod.rs
@@ -14,6 +14,7 @@ use serde::{Serialize, Serializer};
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::fmt::{self, Debug, Display, Formatter};
+use std::hint;
 use std::io::{self, Error as IoError};
 
 pub use catch::{Catch, Propagate};
@@ -271,7 +272,10 @@ impl From<Error> for BoxError {
             ErrorSource::Message(string) => string.into(),
             ErrorSource::Other(source) => source,
             ErrorSource::Json(source) => source.into(),
-            ErrorSource::Restart => "restart".to_owned().into(),
+            ErrorSource::Restart => {
+                hint::cold_path();
+                "restart".to_owned().into()
+            }
         }
     }
 }

--- a/via/src/ws/mod.rs
+++ b/via/src/ws/mod.rs
@@ -21,6 +21,8 @@ pub use error::Result;
 pub use request::Request;
 pub use upgrade::Ws;
 
+use crate::error::{Error, Propagate};
+
 /// Upgrade the connection to a web socket.
 ///
 /// # Example
@@ -67,4 +69,16 @@ where
     Await: Future<Output = Result> + Send,
 {
     Ws::new(listener)
+}
+
+/// Explicitly restarts a listener while keeping the connection intact.
+///
+/// The existing listener will first yield so the reactor can complete pending
+/// tasks.
+pub async fn restart() -> Result {
+    // Immediately yield so the reactor can complete any pending tasks.
+    tokio::task::yield_now().await;
+
+    // Instructs the reactor to replace the listener.
+    Err(Error::restart()).or_continue()
 }

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -320,10 +320,10 @@ where
             None => Pin::new(this.reconnect()).poll(context),
         };
 
-        if let Poll::Ready(Err(ControlFlow::Continue(ref error))) = poll {
-            if error.is_restart() {
-                poll = Pin::new(this.reconnect()).poll(context);
-            }
+        if let Poll::Ready(Err(ControlFlow::Continue(ref error))) = poll
+            && error.is_restart()
+        {
+            poll = Pin::new(this.reconnect()).poll(context);
         }
 
         match poll {

--- a/via/src/ws/run.rs
+++ b/via/src/ws/run.rs
@@ -315,12 +315,18 @@ where
         // Self is also PhantomPinned, preventing self from moving.
         let this = unsafe { self.get_unchecked_mut() };
 
-        let future = match this.facade.as_mut() {
-            Some(facade) => facade,
-            None => this.reconnect(),
+        let mut poll = match this.facade.as_mut() {
+            Some(facade) => Pin::new(facade).poll(context),
+            None => Pin::new(this.reconnect()).poll(context),
         };
 
-        match Pin::new(future).poll(context) {
+        if let Poll::Ready(Err(ControlFlow::Continue(ref error))) = poll {
+            if error.is_restart() {
+                poll = Pin::new(this.reconnect()).poll(context);
+            }
+        }
+
+        match poll {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
             Poll::Ready(Err(ControlFlow::Break(error))) => {
@@ -333,9 +339,13 @@ where
 
                 log!(warn(ws = 1), "{}", &error);
 
-                this.reconnect();
+                // The facade field is no longer valid.
+                this.facade = None;
+
+                // Register an artificial wake.
                 context.waker().wake_by_ref();
 
+                // Return pending.
                 Poll::Pending
             }
         }


### PR DESCRIPTION
Introduces a lag event as part of via-pubsub and the necessary APIs in via required to support first class lag semantics.