### PR TITLE
Revert "chore(via): v2.0.0-gm.63 release"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "=2.0.0-gm.63"
+via = "=2.0.0-gm.62"
 http = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -78,15 +78,15 @@ serde_json = "1"
 time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1", features = ["v4", "serde"] }
-via = { path = "../via", version = "=2.0.0-gm.63" }
+via = { path = "../via", version = "=2.0.0-gm.62" }
 zeroize = { version = "1", features = ["serde"] }
 
 [dependencies.via-diesel]
 path = "../via-diesel"
-version = "=0.1.0-beta.5"
+version = "=0.1.0-beta.4"
 features = ["postgres"]
 
 [dependencies.via-pubsub]
 path = "../via-pubsub"
-version = "=0.1.0-beta.3"
+version = "0.1.0-beta.2"
 features = ["redis"]

--- a/via-diesel/Cargo.toml
+++ b/via-diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-diesel"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.4"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -18,4 +18,4 @@ diesel-async = "0.9"
 diesel = "2"
 http = "1"
 serde = "1"
-via = { version = "=2.0.0-gm.63", path = "../via" }
+via = { version = "=2.0.0-gm.62", path = "../via" }

--- a/via-pubsub/Cargo.toml
+++ b/via-pubsub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-pubsub"
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.2"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ serde = { version = "1" }
 serde_json = "1"
 sha2 = "0.11"
 tokio = "1"
-via = { version = "=2.0.0-gm.63", path = "../via" }
+via = { version = "=2.0.0-gm.62", path = "../via" }
 zeroize = "1"
 
 [dependencies.redis]

--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-gm.63"
+version = "2.0.0-gm.62"
 authors = ["Zakari Papa <pino@hey.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Reverts via-rs/via#639

I noticed there are some outdated dependencies before publishing the latest version and after viewing the changelogs, it seems like a good idea to do so as well.