### PR TITLE
chore(via): update tungstenite to v0.30

### DIFF
--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -82,12 +82,12 @@ version = "0.3"
 optional = true
 
 [dependencies.tungstenite]
-version = "0.29"
+version = "0.30"
 optional = true
 default-features = false
 
 [dependencies.tokio-tungstenite]
-version = "0.29"
+version = "0.30"
 optional = true
 default-features = false
 


### PR DESCRIPTION
Updates tungstenite and tokio-tungstenite to their latest stable release `v0.30`.

## Changelogs
  - [tungstenite](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md#0300)
  - [tokio-tungstenite](https://github.com/snapview/tokio-tungstenite/blob/master/CHANGELOG.md#0300)