### PR TITLE
chore(via): update base64 to v0.23

### DIFF
--- a/via/Cargo.toml
+++ b/via/Cargo.toml
@@ -46,7 +46,7 @@ __test = ["cookie/signed", "fs", "ring", "tokio-tungstenite", "zeroize/serde"]
 
 [dependencies]
 aws-lc-rs = { version = "1", optional = true }
-base64 = { version = "0.22", optional = true }
+base64 = { version = "0.23", optional = true }
 bitflags = "2"
 bytes = "1"
 cookie = { version = "0.18", features = ["percent-encode"] }


### PR DESCRIPTION
Updates base64 to their latest stable release `v0.23`.

## Changelog
  - [base64](https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md#0231)